### PR TITLE
Add a comparison benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,22 @@ bilge-impl = { path = "bilge-impl", version = "=0.1.0" }
 
 [dev-dependencies]
 trybuild = "1.0"
+# examples
 volatile = { git = "https://github.com/theseus-os/volatile" }
 zerocopy = "0.5.0"
+# benches
+criterion = "0.3"
+modular-bitfield = "0.11.2"
+bitbybit = "1.1.4"
+deku = "0.16"
+
+# criterion workaround to make `cargo bench -- --verbose` work
+[lib]
+bench = false
+
+[[bench]]
+name = "compared"
+harness = false
 
 [workspace]
 members = [

--- a/benches/compared/bilge.rs
+++ b/benches/compared/bilge.rs
@@ -1,0 +1,76 @@
+use bilge::{Bitsized, Number, FromBits, bitsize, u4, u12, u20, u5, u2, DebugBits};
+
+pub fn bilge(input: (u32, u32, u64, u16)) {
+    let mut lpi = GicRedistributorLpi {
+        control: RedistributorControl::from(input.0),
+        implementer_identification: RedistributorImplementerIdentification::from(input.1),
+        redistributor_type: RedistributorType::from(input.2),
+    };
+    assert_eq!(lpi.control.value, input.0);
+    assert_eq!(lpi.implementer_identification.value, input.1);
+    assert_eq!(lpi.redistributor_type.value, input.2);
+    
+    assert!(lpi.control.clear_enable_supported());
+    assert_eq!(lpi.implementer_identification.implementer_jep106(), u12::new(2054));
+    lpi.implementer_identification.set_implementer_jep106(u12::new(input.3));
+    assert_eq!(lpi.implementer_identification.implementer_jep106(), u12::new(input.3));
+    assert_eq!(lpi.redistributor_type.processor_number(), 63872);
+}
+
+#[derive(Debug)]
+pub struct GicRedistributorLpi {
+    control: RedistributorControl,
+    implementer_identification: RedistributorImplementerIdentification,
+    redistributor_type: RedistributorType,
+}
+
+#[bitsize(32)]
+#[derive(DebugBits, FromBits)]
+struct RedistributorControl {
+    //ro
+    upstream_write_pending: bool,
+    //zero
+    reserved: u4,
+    //or reserved
+        disable_processor_selection_for_group_1_secure_interrupts: bool,
+        disable_processor_selection_for_group_1_non_secure_interrupts: bool,
+        disable_processor_selection_for_group_0_interrupts: bool,
+    //zero
+    reserved: u20,
+    register_write_pending: bool,
+    lpi_invalidate_registers_supported: bool,
+    clear_enable_supported: bool,
+    enable_lpis: bool,
+}
+
+#[bitsize(32)]
+#[derive(DebugBits, FromBits)]
+struct RedistributorImplementerIdentification {
+    //ro
+    product_id: u8,
+    //zero
+    reserved: u4,
+    //ro
+    variant: u4,
+    //ro
+    revision: u4,
+    implementer_jep106: u12,
+}
+
+#[bitsize(64)]
+#[derive(DebugBits, FromBits)]
+struct RedistributorType {
+    affinity_value: u32,
+    ppi_num: u5,
+    virtual_sgi_supported: bool,
+    common_lpi_affinity: u2, //TODO: enums everywhere
+    processor_number: u16,
+    resident_vpe_id: bool,
+    mpam_supported: bool,
+    control_cpgs_supported: bool,
+    is_last: bool,
+    direct_lpi_supported: bool,
+    dirty: bool,
+    virtual_lpi_supported: bool,
+    physical_lpi_supported: bool,
+}

--- a/benches/compared/bitbybit.rs
+++ b/benches/compared/bitbybit.rs
@@ -1,0 +1,105 @@
+use bitbybit::bitfield;
+use arbitrary_int::{u4, u12, u20, u5, u2};
+
+pub(crate) fn bitbybit(input: (u32, u32, u64, u16)) {
+    let mut lpi = GicRedistributorLpi {
+        control: RedistributorControl::new_with_raw_value(input.0),
+        implementer_identification: RedistributorImplementerIdentification::new_with_raw_value(input.1),
+        redistributor_type: RedistributorType::new_with_raw_value(input.2),
+    };
+    assert_eq!(lpi.control.raw_value, input.0);
+    assert_eq!(lpi.implementer_identification.raw_value, input.1);
+    assert_eq!(lpi.redistributor_type.raw_value, input.2);
+    
+    assert!(lpi.control.clear_enable_supported());
+    assert_eq!(lpi.implementer_identification.implementer_jep106(), u12::new(2054));
+    lpi.implementer_identification = lpi.implementer_identification.with_implementer_jep106(u12::new(input.3));
+    assert_eq!(lpi.implementer_identification.implementer_jep106(), u12::new(input.3));
+    assert_eq!(lpi.redistributor_type.processor_number(), 63872);
+}
+
+#[derive(Debug)]
+pub struct GicRedistributorLpi {
+    control: RedistributorControl,
+    implementer_identification: RedistributorImplementerIdentification,
+    redistributor_type: RedistributorType,
+}
+
+#[bitfield(u32)]
+#[derive(Debug)]
+struct RedistributorControl {
+    //ro
+    #[bit(0, rw)]
+    upstream_write_pending: bool,
+    //zero
+    #[bits(1..=4, rw)]
+    reserved_i: u4,
+    //or reserved
+        #[bit(5, rw)]
+        disable_processor_selection_for_group_1_secure_interrupts: bool,
+        #[bit(6, rw)]
+        disable_processor_selection_for_group_1_non_secure_interrupts: bool,
+        #[bit(7, rw)]
+        disable_processor_selection_for_group_0_interrupts: bool,
+    //zero
+    #[bits(8..=27, rw)]
+    reserved_ii: u20,
+    #[bit(28, rw)]
+    register_write_pending: bool,
+    #[bit(29, rw)]
+    lpi_invalidate_registers_supported: bool,
+    #[bit(30, rw)]
+    clear_enable_supported: bool,
+    #[bit(31, rw)]
+    enable_lpis: bool,
+}
+
+#[bitfield(u32)]
+#[derive(Debug)]
+struct RedistributorImplementerIdentification {
+    //ro
+    #[bits(0..=7, rw)]
+    product_id: u8,
+    //zero
+    #[bits(8..=11, rw)]
+    reserved: u4,
+    //ro
+    #[bits(12..=15, rw)]
+    variant: u4,
+    //ro
+    #[bits(16..=19, rw)]
+    revision: u4,
+    #[bits(20..=31, rw)]
+    implementer_jep106: u12,
+}
+
+#[bitfield(u64)]
+#[derive(Debug)]
+struct RedistributorType {
+    #[bits(0..=31, rw)]
+    affinity_value: u32,
+    #[bits(32..=36, rw)]
+    ppi_num: u5,
+    #[bit(37, rw)]
+    virtual_sgi_supported: bool,
+    #[bits(38..=39, rw)]
+    common_lpi_affinity: u2, //TODO: enums everywhere
+    #[bits(40..=55, rw)]
+    processor_number: u16,
+    #[bit(56, rw)]
+    resident_vpe_id: bool,
+    #[bit(57, rw)]
+    mpam_supported: bool,
+    #[bit(58, rw)]
+    control_cpgs_supported: bool,
+    #[bit(59, rw)]
+    is_last: bool,
+    #[bit(60, rw)]
+    direct_lpi_supported: bool,
+    #[bit(61, rw)]
+    dirty: bool,
+    #[bit(62, rw)]
+    virtual_lpi_supported: bool,
+    #[bit(63, rw)]
+    physical_lpi_supported: bool,
+}

--- a/benches/compared/deku.rs
+++ b/benches/compared/deku.rs
@@ -1,0 +1,136 @@
+use deku::{DekuRead, DekuWrite, DekuUpdate, DekuContainerWrite};
+
+/// Don't take this example as "the way to use deku", please.
+/// This is just a faulty implementation, but even just providing a value
+/// and getting it out again is currently (26.04.2023) not `const` in deku,
+/// so we'll wait until (if) that happens.
+pub(crate) fn deku(input: (u32, u32, u64, u16)) {       //input.0 = 0b1111_0000_0000_1001_1111_0000_0000_1001
+    let mut control: [u8; 4] = input.0.to_le_bytes();   //[0b0000_1001, 0b1111_0000, 0b0000_1001, 0b1111_0000]
+    for byte in &mut control {                          //[0b1001_0000, 0b0000_1111, 0b1001_0000, 0b0000_1111]
+        *byte = byte.reverse_bits();                    // these lines convert to deku's expected inputs
+    }
+
+    let mut implementer_identification: [u8; 4] = input.1.to_le_bytes();
+    for byte in &mut implementer_identification {
+        *byte = byte.reverse_bits();
+    }
+
+    let mut redistributor_type: [u8; 8] = input.2.to_le_bytes();
+    for byte in &mut redistributor_type {
+        *byte = byte.reverse_bits();
+    }
+
+    let mut lpi = GicRedistributorLpi {
+        control: RedistributorControl::try_from(control.as_slice()).expect("1"),
+        implementer_identification: RedistributorImplementerIdentification::try_from(implementer_identification.as_slice()).expect("2"),
+        redistributor_type: RedistributorType::try_from(redistributor_type.as_slice()).expect("3"),
+    };
+
+    let mut control: [u8; 4] = lpi.control.to_bytes().unwrap()[0..4].try_into().unwrap();
+    for byte in &mut control {
+        *byte = byte.reverse_bits();
+    }
+    let control = u32::from_le_bytes(control);
+    let mut implementer_identification: [u8; 4] = lpi.implementer_identification.to_bytes().unwrap()[0..4].try_into().unwrap();
+    for byte in &mut implementer_identification {
+        *byte = byte.reverse_bits();
+    }
+    let implementer_identification = u32::from_le_bytes(implementer_identification);
+    let mut redistributor_type: [u8; 8] = lpi.redistributor_type.to_bytes().unwrap()[0..8].try_into().unwrap();
+    for byte in &mut redistributor_type {
+        *byte = byte.reverse_bits();
+    }
+    let redistributor_type = u64::from_le_bytes(redistributor_type);
+    assert_eq!(control, input.0);
+    assert_eq!(implementer_identification, input.1);
+    assert_eq!(redistributor_type, input.2);
+    
+    assert!(lpi.control.clear_enable_supported);
+    // after trying for too much time, I will not fix this;
+    // maybe one needs to use some special API to read values
+    // assert_eq!(lpi.implementer_identification.implementer_jep106, 2054);
+    lpi.implementer_identification.implementer_jep106 = input.3;
+    // this of course works since we just set field, get field
+    assert_eq!(lpi.implementer_identification.implementer_jep106, input.3);
+    // assert_eq!(lpi.redistributor_type.processor_number, 63872);
+}
+
+#[derive(Debug)]
+pub struct GicRedistributorLpi {
+    control: RedistributorControl,
+    implementer_identification: RedistributorImplementerIdentification,
+    redistributor_type: RedistributorType,
+}
+
+#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+struct RedistributorControl {
+    //ro
+    #[deku(bits = "1")]
+    upstream_write_pending: bool,
+    //zero
+    #[deku(bits = "4")]
+    reserved_i: u8,
+    //or reserved
+        #[deku(bits = "1")]
+        disable_processor_selection_for_group_1_secure_interrupts: bool,
+        #[deku(bits = "1")]
+        disable_processor_selection_for_group_1_non_secure_interrupts: bool,
+        #[deku(bits = "1")]
+        disable_processor_selection_for_group_0_interrupts: bool,
+    //zero
+    #[deku(bits = "20")]
+    reserved_ii: u32,
+    #[deku(bits = "1")]
+    register_write_pending: bool,
+    #[deku(bits = "1")]
+    lpi_invalidate_registers_supported: bool,
+    #[deku(bits = "1")]
+    clear_enable_supported: bool,
+    #[deku(bits = "1")]
+    enable_lpis: bool,
+}
+
+#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+struct RedistributorImplementerIdentification {
+    //ro
+    product_id: u8,
+    //zero
+    #[deku(bits = "4")]
+    reserved: u8,
+    //ro
+    #[deku(bits = "4")]
+    variant: u8,
+    //ro
+    #[deku(bits = "4")]
+    revision: u8,
+    #[deku(bits = "12")]
+    implementer_jep106: u16,
+}
+
+#[derive(Debug, PartialEq, DekuRead, DekuWrite)]
+struct RedistributorType {
+    affinity_value: u32,
+    #[deku(bits = "5")]
+    ppi_num: u8,
+    #[deku(bits = "1")]
+    virtual_sgi_supported: bool,
+    #[deku(bits = "2")]
+    common_lpi_affinity: u8, //TODO: enums everywhere
+    processor_number: u16,
+    #[deku(bits = "1")]
+    resident_vpe_id: bool,
+    #[deku(bits = "1")]
+    mpam_supported: bool,
+    #[deku(bits = "1")]
+    control_cpgs_supported: bool,
+    #[deku(bits = "1")]
+    is_last: bool,
+    #[deku(bits = "1")]
+    direct_lpi_supported: bool,
+    #[deku(bits = "1")]
+    dirty: bool,
+    #[deku(bits = "1")]
+    virtual_lpi_supported: bool,
+    #[deku(bits = "1")]
+    physical_lpi_supported: bool,
+}

--- a/benches/compared/handmade.rs
+++ b/benches/compared/handmade.rs
@@ -1,0 +1,149 @@
+#![allow(dead_code)]
+
+//TODO: version with arbints or range checking? (to just get its benefits)
+pub(crate) fn handmade(input: (u32, u32, u64, u16)) {
+    let mut lpi = GicRedistributorLpi {
+        control: RedistributorControl(input.0),
+        implementer_identification: RedistributorImplementerIdentification(input.1),
+        redistributor_type: RedistributorType(input.2),
+    };
+    assert_eq!(lpi.control.0, input.0);
+    assert_eq!(lpi.implementer_identification.0, input.1);
+    assert_eq!(lpi.redistributor_type.0, input.2);
+    
+    assert!(lpi.control.clear_enable_supported());
+    assert_eq!(lpi.implementer_identification.implementer_jep106(), 2054);
+    lpi.implementer_identification.set_implementer_jep106(input.3);
+    assert_eq!(lpi.implementer_identification.implementer_jep106(), input.3);
+    assert_eq!(lpi.redistributor_type.processor_number(), 63872);
+}
+
+#[derive(Debug)]
+pub struct GicRedistributorLpi {
+    control: RedistributorControl,
+    implementer_identification: RedistributorImplementerIdentification,
+    redistributor_type: RedistributorType,
+}
+
+#[derive(Debug)]
+struct RedistributorControl(u32);
+impl RedistributorControl {
+    //ro
+    const fn upstream_write_pending(&self) -> bool {
+        self.0 & 1 != 0
+    }
+    //zero
+    //u4
+    const fn reserved_i(&self) -> u8 {
+        (self.0 >> 1) as u8 & 0b1111
+    }
+    //or reserved
+        const fn disable_processor_selection_for_group_1_secure_interrupts(&self) -> bool {
+            (self.0 >> 5) & 1 != 0
+
+        }
+        const fn disable_processor_selection_for_group_1_non_secure_interrupts(&self) -> bool {
+            (self.0 >> 6) & 1 != 0
+        }
+        const fn disable_processor_selection_for_group_0_interrupts(&self) -> bool {
+            (self.0 >> 7) & 1 != 0
+        }
+    //zero
+    //u20
+    const fn reserved_ii(&self) -> u32 {
+        (self.0 >> 8) & 0b1111_1111_1111_1111_1111
+    }
+    const fn register_write_pending(&self) -> bool {
+        (self.0 >> 27) & 1 != 0
+    }
+    const fn lpi_invalidate_registers_supported(&self) -> bool {
+        (self.0 >> 28) & 1 != 0
+    }
+    const fn clear_enable_supported(&self) -> bool {
+        (self.0 >> 29) & 1 != 0
+    }
+    const fn enable_lpis(&self) -> bool {
+        (self.0 >> 30) & 1 != 0
+    }
+}
+
+#[derive(Debug)]
+struct RedistributorImplementerIdentification(u32);
+impl RedistributorImplementerIdentification {
+    //ro
+    const fn product_id(&self) -> u8 {
+        self.0 as u8
+    }
+    //zero
+    //u4
+    const fn reserved_i(&self) -> u8 {
+        (self.0 >> 8) as u8 & 0b1111
+    }
+    //ro
+    //u4
+    const fn variant(&self) -> u8 {
+        (self.0 >> 12) as u8 & 0b1111
+    }
+    //ro
+    //u4
+    const fn revision(&self) -> u8 {
+        (self.0 >> 16) as u8 & 0b1111
+    }
+    //u12
+    const fn implementer_jep106(&self) -> u16 {
+        (self.0 >> 20) as u16 & 0b1111_1111_1111
+    }
+    //u12
+    const fn set_implementer_jep106(&mut self, value: u16) {
+        let this_value = ((value & 0b1111_1111_1111) as u32) << 20;
+        let others_mask = !(0b1111_1111_1111 << 20);
+        let other_values = self.0 & others_mask;
+        self.0 = other_values | this_value;
+    }
+}
+
+#[derive(Debug)]
+struct RedistributorType(u64);
+impl RedistributorType {
+    const fn affinity_value(&self) -> u32 {
+        self.0 as u32
+    }
+    //u5
+    const fn ppi_num(&self) -> u8 {
+        (self.0 >> 32) as u8 & 0b1_1111
+    }
+    const fn virtual_sgi_supported(&self) -> bool {
+        (self.0 >> 37) & 1 != 0
+    }
+    //u2
+    const fn common_lpi_affinity(&self) -> u8 {
+        (self.0 >> 38) as u8 & 0b11
+    }
+    const fn processor_number(&self) -> u16 {
+        (self.0 >> 40) as u16
+    }
+    const fn resident_vpe_id(&self) -> bool {
+        (self.0 >> 56) & 1 != 0
+    }
+    const fn mpam_supported(&self) -> bool {
+        (self.0 >> 57) & 1 != 0
+    }
+    const fn control_cpgs_supported(&self) -> bool {
+        (self.0 >> 58) & 1 != 0
+    }
+    const fn is_last(&self) -> bool {
+        (self.0 >> 59) & 1 != 0
+    }
+    const fn direct_lpi_supported(&self) -> bool {
+        (self.0 >> 60) & 1 != 0
+    }
+    const fn dirty(&self) -> bool {
+        (self.0 >> 61) & 1 != 0
+    }
+    const fn virtual_lpi_supported(&self) -> bool {
+        (self.0 >> 62) & 1 != 0
+    }
+    const fn physial_lpi_supported(&self) -> bool {
+        (self.0 >> 63) & 1 != 0
+    }
+}

--- a/benches/compared/main.rs
+++ b/benches/compared/main.rs
@@ -1,0 +1,50 @@
+#![feature(const_trait_impl, const_convert, const_mut_refs)]
+use criterion::{criterion_group, criterion_main, Criterion, BenchmarkId};
+
+mod bilge;
+mod bitbybit;
+mod modular;
+mod handmade;
+// mod deku;
+
+/// This is a benchmark testing basic construction from bytes and getters, setters.
+/// For modular and deku, the input is converted inside their respective function,
+/// since that conversion is const.
+/// 
+/// on my random hardware config, these are all running at ~2.4ns, besides deku at ~15µs
+pub fn bitfields_compared(c: &mut Criterion) {
+    let input1: (u32, u32, u64, u16) = (
+        // clear_enable_supported = true
+        0b1111_0000_0000_1001_1111_0000_0000_1001,
+        // implementer_jep106 = 2054
+        0b1000_0000_0110_1001_1111_1111_0010_1001,
+        // processor_number = 63872
+        0b1000_1111_1111_1001_1000_0000_0110_1001_1111_1111_0010_1001_1111_1111_0010_1001,
+        // for setting implementer_jep106
+        0b0101_0111_1111
+    );
+
+    let mut group = c.benchmark_group("compared");
+    // for i in [input1, ...].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("bilge", "input1"), &input1, |b, i| b.iter(|| crate::bilge::bilge(*i))
+        );
+        group.bench_with_input(
+            BenchmarkId::new("bitbybit", "input1"), &input1, |b, i| b.iter(|| crate::bitbybit::bitbybit(*i))
+        );
+        group.bench_with_input(
+            BenchmarkId::new("modular", "input1"), &input1, |b, i| b.iter(|| crate::modular::modular(*i))
+        );
+        group.bench_with_input(
+            BenchmarkId::new("handmade", "input1"), &input1, |b, i| b.iter(|| crate::handmade::handmade(*i))
+        );
+        // uncomment once deku/bitvec is more `const`
+        // group.bench_with_input(
+        //     BenchmarkId::new("deku", "input1"), &input1, |b, i| b.iter(|| crate::deku::deku(*i))
+        // );
+    // }
+    group.finish();
+}
+
+criterion_group!(benches, bitfields_compared);
+criterion_main!(benches);

--- a/benches/compared/modular.rs
+++ b/benches/compared/modular.rs
@@ -1,0 +1,84 @@
+// we need to put this on the whole module since bitfield doesn't pass it through
+// (into_bytes, new is never used)
+#![allow(dead_code)]
+use modular_bitfield::{bitfield, specifiers::{B20, B4, B12, B5, B2}, Specifier};
+
+pub(crate) fn modular(input: (u32, u32, u64, u16)) {
+    // convert to modular_bitfield's expected inputs
+    let control: [u8; 4] = input.0.to_le_bytes();
+    let implementer_identification: [u8; 4] = input.1.to_le_bytes();
+    let redistributor_type: [u8; 8] = input.2.to_le_bytes();
+
+    let mut lpi = GicRedistributorLpi {
+        control: RedistributorControl::from_bytes(control),
+        implementer_identification: RedistributorImplementerIdentification::from_bytes(implementer_identification),
+        redistributor_type: RedistributorType::from_bytes(redistributor_type),
+    };
+    assert_eq!(u32::from_le_bytes(lpi.control.bytes), input.0);
+    assert_eq!(u32::from_le_bytes(lpi.implementer_identification.bytes), input.1);
+    assert_eq!(u64::from_le_bytes(lpi.redistributor_type.bytes), input.2);
+    
+    assert!(lpi.control.clear_enable_supported());
+    assert_eq!(lpi.implementer_identification.implementer_jep106(), 2054); //B12?
+    lpi.implementer_identification.set_implementer_jep106(B12::from_bytes(input.3).unwrap()); //`from_bytes` does not always get bytes..
+    assert_eq!(lpi.implementer_identification.implementer_jep106(), input.3); //B12?
+    assert_eq!(lpi.redistributor_type.processor_number(), 63872);
+}
+
+#[derive(Debug)]
+pub struct GicRedistributorLpi {
+    control: RedistributorControl,
+    implementer_identification: RedistributorImplementerIdentification,
+    redistributor_type: RedistributorType,
+}
+
+#[bitfield(bits = 32)]
+#[derive(Debug)]
+struct RedistributorControl {
+    //ro
+    upstream_write_pending: bool,
+    //zero
+    reserved_i: B4,
+    //or reserved
+        disable_processor_selection_for_group_1_secure_interrupts: bool,
+        disable_processor_selection_for_group_1_non_secure_interrupts: bool,
+        disable_processor_selection_for_group_0_interrupts: bool,
+    //zero
+    reserved_ii: B20,
+    register_write_pending: bool,
+    lpi_invalidate_registers_supported: bool,
+    clear_enable_supported: bool,
+    enable_lpis: bool,
+}
+
+#[bitfield(bits = 32)]
+#[derive(Debug)]
+struct RedistributorImplementerIdentification {
+    //ro
+    product_id: u8,
+    //zero
+    reserved: B4,
+    //ro
+    variant: B4,
+    //ro
+    revision: B4,
+    implementer_jep106: B12,
+}
+
+#[bitfield(bits = 64)]
+#[derive(Debug)]
+struct RedistributorType {
+    affinity_value: u32,
+    ppi_num: B5,
+    virtual_sgi_supported: bool,
+    common_lpi_affinity: B2, //TODO: enums everywhere
+    processor_number: u16,
+    resident_vpe_id: bool,
+    mpam_supported: bool,
+    control_cpgs_supported: bool,
+    is_last: bool,
+    direct_lpi_supported: bool,
+    dirty: bool,
+    virtual_lpi_supported: bool,
+    physical_lpi_supported: bool,
+}

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{TokenStream, Ident};
 use proc_macro_error::{abort_call_site, abort};
 use quote::{quote, ToTokens};
-use syn::{Item, ItemStruct, Type,ItemEnum, Attribute, Fields, Meta, parse_quote, spanned::Spanned};
+use syn::{Item, ItemStruct, ItemEnum, Type, Attribute, Fields, Meta, parse_quote, spanned::Spanned};
 
 use crate::shared::{self, BitSize, unreachable};
 
@@ -49,7 +49,7 @@ struct SplitAttributes {
     after_compression: Vec<Attribute>,
 }
 
-/// Intermediate Representation
+/// Intermediate Representation, just for bundling these together
 struct ItemIr {
     name: Ident,
     /// needed in from_bits and try_from_bits
@@ -195,6 +195,8 @@ fn generate_filled_check_for(ty: &Type) -> TokenStream {
     }
 }
 
+/// Allows you to give multiple fields the name `reserved` or `padding`
+/// by numbering them for you.
 fn modify_special_field_names(fields: &mut Fields) {
     // We could have just counted up, i.e. `reserved_0`, but people might interpret this as "reserved to zero".
     // Using some other, more useful unique info as postfix would be nice.
@@ -242,7 +244,7 @@ fn generate_struct(item: &ItemStruct, declared_bitsize: u8) -> TokenStream {
     let declared_bitsize = declared_bitsize as usize;
 
     let computed_bitsize = fields.iter().fold(quote!(0), |acc, next| {
-        let field_size = shared::analyze_field_bitsize(&next.ty);
+        let field_size = shared::generate_field_bitsize(&next.ty);
         quote!(#acc + #field_size)
     });
 

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -58,8 +58,8 @@ struct ItemIr {
     expanded: TokenStream,
 }
 
-pub(super) fn bitsize(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let (item, declared_bitsize) = parse(item, attr);
+pub(super) fn bitsize(args: TokenStream, item: TokenStream) -> TokenStream {
+    let (item, declared_bitsize) = parse(item, args);
     let attrs = split_attributes(&item);
     let ir = match item {
         Item::Struct(mut item) => {
@@ -80,14 +80,14 @@ pub(super) fn bitsize(attr: TokenStream, item: TokenStream) -> TokenStream {
     generate_common(ir, attrs, declared_bitsize)
 }
 
-fn parse(item: TokenStream, attr: TokenStream) -> (Item, BitSize) {
+fn parse(item: TokenStream, args: TokenStream) -> (Item, BitSize) {
     let item = syn::parse2(item).unwrap_or_else(unreachable);
 
-    if attr.is_empty() {
+    if args.is_empty() {
         abort_call_site!("missing attribute value"; help = "you need to define the size like this: `#[bitsize(32)]`")
     }
     
-    let (declared_bitsize, _arb_int) = shared::bitsize_and_arbitrary_int_from(attr);
+    let (declared_bitsize, _arb_int) = shared::bitsize_and_arbitrary_int_from(args);
     if declared_bitsize > shared::MAX_STRUCT_BIT_SIZE {
         abort_call_site!("attribute is not a valid number"; help = "currently, numbers from 1 to {} are allowed", shared::MAX_STRUCT_BIT_SIZE)
     }

--- a/bilge-impl/src/bitsize_internal.rs
+++ b/bilge-impl/src/bitsize_internal.rs
@@ -1,12 +1,12 @@
 use proc_macro2::{TokenStream, Ident};
 use quote::quote;
-use syn::{Item, ItemStruct, Type, ItemEnum, Attribute, Field};
+use syn::{Item, ItemStruct, ItemEnum, Type, Attribute, Field};
 
 use crate::shared::{self, unreachable};
 
 pub(crate) mod struct_gen;
 
-/// Intermediate Representation
+/// Intermediate Representation, just for bundling these together
 struct ItemIr<'a> {
     attrs: &'a Vec<Attribute>,
     name: &'a Ident,
@@ -47,7 +47,7 @@ fn generate_struct(struct_data: &ItemStruct, arb_int: &TokenStream) -> TokenStre
     let mut previous_field_sizes = vec![];
     let (accessors, (constructor_args, constructor_parts)): (Vec<TokenStream>, (Vec<TokenStream>, Vec<TokenStream>)) = fields.iter()
         .map(|field| {
-            let field_size = shared::analyze_field_bitsize(&field.ty);
+            let field_size = shared::generate_field_bitsize(&field.ty);
             // offset is needed for bit-shifting
             // struct Example { field1: u8, field2: u4, field3: u4 }
             // previous_field_sizes = []     -> unwrap_or_else -> field_offset = 0

--- a/bilge-impl/src/bitsize_internal.rs
+++ b/bilge-impl/src/bitsize_internal.rs
@@ -14,8 +14,8 @@ struct ItemIr<'a> {
     expanded: TokenStream,
 }
 
-pub(super) fn bitsize_internal(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let (item, arb_int) = parse(item, attr);
+pub(super) fn bitsize_internal(args: TokenStream, item: TokenStream) -> TokenStream {
+    let (item, arb_int) = parse(item, args);
     let ir = match item {
         Item::Struct(ref item) => {
             let expanded = generate_struct(item, &arb_int);
@@ -34,9 +34,9 @@ pub(super) fn bitsize_internal(attr: TokenStream, item: TokenStream) -> TokenStr
     generate_common(ir, &arb_int)
 }
 
-fn parse(item: TokenStream, attr: TokenStream) -> (Item, TokenStream) {
+fn parse(item: TokenStream, args: TokenStream) -> (Item, TokenStream) {
     let item = syn::parse2(item).unwrap_or_else(unreachable);
-    let (_declared_bitsize, arb_int) = shared::bitsize_and_arbitrary_int_from(attr);
+    let (_declared_bitsize, arb_int) = shared::bitsize_and_arbitrary_int_from(args);
     (item, arb_int)
 }
 

--- a/bilge-impl/src/bitsize_internal/struct_gen.rs
+++ b/bilge-impl/src/bitsize_internal/struct_gen.rs
@@ -82,7 +82,7 @@ pub(crate) fn generate_getter_inner(ty: &Type, is_getter: bool) -> TokenStream {
             }
         },
         Path(_) => {
-            let size = shared::analyze_field_bitsize(ty);
+            let size = shared::generate_field_bitsize(ty);
             let mask = generate_ty_mask(ty);
             let return_statement = if is_getter {
                 quote! {
@@ -194,7 +194,7 @@ fn generate_setter_inner(ty: &Type) -> TokenStream {
             } }
         },
         Path(_) => {
-            let size = shared::analyze_field_bitsize(ty);
+            let size = shared::generate_field_bitsize(ty);
             quote! { {
                 let value: BaseIntOf<#ty> = <ArbIntOf<#ty>>::from(value).value();
                 let value: BaseIntOf<Self> = value as BaseIntOf<Self>;
@@ -226,7 +226,7 @@ fn generate_ty_mask(ty: &Type) -> TokenStream {
             tuple.elems.iter()
                 .map(|elem| {
                     let mask = generate_ty_mask(elem);
-                    let elem_size = shared::analyze_field_bitsize(elem);
+                    let elem_size = shared::generate_field_bitsize(elem);
                     let elem_offset = previous_elem_sizes.iter().cloned().reduce(|acc, next| quote!((#acc + #next)));
                     previous_elem_sizes.push(elem_size);
                     if let Some(elem_offset) = elem_offset {
@@ -243,7 +243,7 @@ fn generate_ty_mask(ty: &Type) -> TokenStream {
             let elem_ty = &array.elem;
             let len_expr = &array.len;
             let mask = generate_ty_mask(elem_ty);
-            let ty_size = shared::analyze_field_bitsize(elem_ty);
+            let ty_size = shared::generate_field_bitsize(elem_ty);
             quote! { {
                 let mask = #mask;
                 let mut field_mask = 0;

--- a/bilge-impl/src/debug_bits.rs
+++ b/bilge-impl/src/debug_bits.rs
@@ -5,7 +5,6 @@ use syn::{Data, Fields};
 
 use crate::shared::{self, unreachable};
 
-
 pub(super) fn debug_bits(item: TokenStream) -> TokenStream {
     let derive_input = shared::parse_derive(item);
     let name = &derive_input.ident;

--- a/bilge-impl/src/lib.rs
+++ b/bilge-impl/src/lib.rs
@@ -17,16 +17,16 @@ mod shared;
 /// Please open an issue if you have a usecase for bigger bitfields.
 #[proc_macro_error]
 #[proc_macro_attribute]
-pub fn bitsize(attr: TokenStream, item: TokenStream) -> TokenStream {
-    bitsize::bitsize(attr.into(), item.into()).into()
+pub fn bitsize(args: TokenStream, item: TokenStream) -> TokenStream {
+    bitsize::bitsize(args.into(), item.into()).into()
 }
 
 /// This is internally used, not to be used by anything besides `bitsize`.
 /// No guarantees are given.
 #[proc_macro_error]
 #[proc_macro_attribute]
-pub fn bitsize_internal(attr: TokenStream, item: TokenStream) -> TokenStream {
-    bitsize_internal::bitsize_internal(attr.into(), item.into()).into()
+pub fn bitsize_internal(args: TokenStream, item: TokenStream) -> TokenStream {
+    bitsize_internal::bitsize_internal(args.into(), item.into()).into()
 }
 
 /// Generate an `impl TryFrom<uN>` for unfilled bitfields.

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -70,17 +70,17 @@ pub fn bitsize_and_arbitrary_int_from(bitsize_arg: TokenStream) -> (BitSize, Tok
     (bitsize, arb_int)
 }
 
-pub fn analyze_field_bitsize(ty: &Type) -> TokenStream {
+pub fn generate_field_bitsize(ty: &Type) -> TokenStream {
     use Type::*;
     match ty {
         Tuple(tuple) => {
-            tuple.elems.iter().map(analyze_field_bitsize)
+            tuple.elems.iter().map(generate_field_bitsize)
                 .reduce(|acc, next| quote!((#acc + #next)))
                 // `field: (),` will be handled like this:
                 .unwrap_or_else(|| quote!(0))
         },
         Array(array) => {
-            let elem_bitsize = analyze_field_bitsize(&array.elem);
+            let elem_bitsize = generate_field_bitsize(&array.elem);
             let len_expr = &array.len;
             quote!((#elem_bitsize * #len_expr))
         },


### PR DESCRIPTION
- also modifies some naming and adds a few comments
- this is just a basic sanity test right now

Keep in mind that the deku benchmark is not final and commented out.
Also, I didn't use some functionality (like bitbybit read-only) since asm output and performance was pretty much the same across all of them. Some more complex benchmarks should test those.