### PR TITLE
Only generate getters for `reserved`, add better docs and generate less scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ I wanted a design fitting rust:
 
 The lib is **no-std** (and fully `const` behind a `"nightly"` feature gate).
 
+For some more explanations on the "why" and "how": [blog post](https://hecatia-elegua.github.io/blog/no-more-bit-fiddling/) and [reddit comments](https://www.reddit.com/r/rust/comments/13ic0mf/no_more_bit_fiddling_and_introducing_bilge/).
+
 ## WARNING
 
 Our current version is still pre 1.0, which means nothing is completely stable.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This shows `TryFrom` being propagated upward. There's also another small help: `
 Again, let's try to print this:
 ```rust
 println!("{:?}", Device::try_from(0b0000_11_00));
+println!("{:?}", Device::new(Class::Mobile));
 ```
 And again, `Device` doesn't implement `Debug`:
 
@@ -125,6 +126,7 @@ And again, `Device` doesn't implement `Debug`:
 For structs, you need to add `#[derive(DebugBits)]` to get an output like this:
 ```rust
 Ok(Device { reserved_i: 0, class: Stationary, reserved_ii: 0 })
+Device { reserved_i: 0, class: Mobile, reserved_ii: 0 }
 ```
 
 ## Back- and Forwards Compatibility

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -244,7 +244,7 @@ fn generate_struct(item: &ItemStruct, declared_bitsize: u8) -> TokenStream {
     let declared_bitsize = declared_bitsize as usize;
 
     let computed_bitsize = fields.iter().fold(quote!(0), |acc, next| {
-        let field_size = shared::generate_field_bitsize(&next.ty);
+        let field_size = shared::generate_type_bitsize(&next.ty);
         quote!(#acc + #field_size)
     });
 

--- a/bilge-impl/src/bitsize_internal.rs
+++ b/bilge-impl/src/bitsize_internal.rs
@@ -47,13 +47,13 @@ fn generate_struct(struct_data: &ItemStruct, arb_int: &TokenStream) -> TokenStre
     let mut previous_field_sizes = vec![];
     let (accessors, (constructor_args, constructor_parts)): (Vec<TokenStream>, (Vec<TokenStream>, Vec<TokenStream>)) = fields.iter()
         .map(|field| {
-            let field_size = shared::generate_field_bitsize(&field.ty);
             // offset is needed for bit-shifting
             // struct Example { field1: u8, field2: u4, field3: u4 }
             // previous_field_sizes = []     -> unwrap_or_else -> field_offset = 0
             // previous_field_sizes = [8]    -> reduce         -> field_offset = 0 + 8     =  8
             // previous_field_sizes = [8, 4] -> reduce         -> field_offset = 0 + 8 + 4 = 12
             let field_offset = previous_field_sizes.iter().cloned().reduce(|acc, next| quote!(#acc + #next)).unwrap_or_else(|| quote!(0));
+            let field_size = shared::generate_type_bitsize(&field.ty);
             previous_field_sizes.push(field_size);
             generate_field(field, &field_offset, &mut fieldless_next_int)
     }).unzip();

--- a/bilge-impl/src/bitsize_internal.rs
+++ b/bilge-impl/src/bitsize_internal.rs
@@ -96,6 +96,14 @@ fn generate_field(field: &Field, field_offset: &TokenStream, fieldless_next_int:
         syn::parse_str(&name).unwrap_or_else(unreachable)
     };
 
+    // skip reserved fields in constructors and setters
+    let name_str = name.to_string();
+    if name_str.contains("reserved_") || name_str.contains("padding_") {
+        // needed for `DebugBits`
+        let getter = generate_getter(field, field_offset, &name);
+        return (quote!(#getter), (quote!(), quote!(0)))
+    }
+
     let getter = generate_getter(field, field_offset, &name);
     let setter = generate_setter(field, field_offset, &name);
     let (constructor_arg, constructor_part) = generate_constructor_stuff(ty, &name);

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -81,9 +81,7 @@ fn codegen_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields) ->
             }
         })
         .reduce(|acc, next| quote!((#acc && #next)))
-        // this returns true when all fields are arbitrary ints, e.g. u4
-        // (or maybe also if there are no fields)
-        // TODO: Should it then be From instead of TryFrom?
+        // `Struct {}` would be handled like this:
         .unwrap_or_else(|| quote!(true));
 
     let const_ = if cfg!(feature = "nightly") {

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -69,7 +69,7 @@ fn codegen_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields) ->
         .map(|field| {
             let ty = &field.ty;
             if shared::is_always_filled(ty) {
-                let size = shared::generate_field_bitsize(ty);
+                let size = shared::generate_type_bitsize(ty);
                 quote! { {
                     // we still need to shift by the element's size
                     let size = #size;

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -49,4 +49,5 @@ fn main() {
     let class = Class::try_from(u2::new(2));
     assert_eq!(class, Err(u2::new(2)));
     println!("{:?}", Device::try_from(0b0000_11_00));
+    println!("{:?}", Device::new(Class::Mobile));
 }


### PR DESCRIPTION
kinda a kitchen sink PR, which is fine