### PR TITLE
Add "reserved" attribute for an enum variant, allowing derive(FromBits) even if unfilled

### DIFF
--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -18,7 +18,7 @@ pub(super) fn from_bits(item: TokenStream) -> TokenStream {
         },
         _ => unreachable(()),
     };
-    generate_common(expanded, name, &fallback)
+    generate_common(expanded, name)
 }
 
 fn parse(item: TokenStream) -> DeriveInput {
@@ -118,8 +118,7 @@ fn generate_struct(arb_int: TokenStream, struct_type: &Ident) -> TokenStream {
     }
 }
 
-fn generate_common(expanded: TokenStream, type_name: &Ident, _fallback_variant: &Option<Variant>) -> TokenStream {
-    // TODO: if fallback_variant.is_some(), an assert should not be generated
+fn generate_common(expanded: TokenStream, type_name: &Ident) -> TokenStream {
     quote! {
         #expanded
 

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -13,8 +13,8 @@ pub(super) fn from_bits(item: TokenStream) -> TokenStream {
         },
         Data::Enum(ref enum_data) => {
             let variants = enum_data.variants.iter();
-            let match_arms = analyze_enum(variants, name, internal_bitsize, &fallback);
-            generate_enum(arb_int, name, match_arms, &fallback)
+            let match_arms = analyze_enum(variants, name, internal_bitsize, fallback);
+            generate_enum(arb_int, name, match_arms, fallback)
         },
         _ => unreachable(()),
     };
@@ -25,11 +25,11 @@ fn parse(item: TokenStream) -> DeriveInput {
     shared::parse_derive(item)
 }
 
-fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitSize, Option<Variant>) {
+fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitSize, Option<&Variant>) {
     shared::analyze_derive(derive_input, false)
 }
 
-fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize, fallback: &Option<Variant>) -> (Vec<TokenStream>, Vec<TokenStream>) {
+fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize, fallback: Option<&Variant>) -> (Vec<TokenStream>, Vec<TokenStream>) {
     // in enums, internal_bitsize <= 64; u64::MAX + 1 = u128
     
     let enum_is_filled = enum_fills_bitsize(internal_bitsize, variants.len());
@@ -61,7 +61,7 @@ fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize
     }).unzip()
 }
 
-fn generate_enum(arb_int: TokenStream, enum_type: &Ident, match_arms: (Vec<TokenStream>, Vec<TokenStream>), fallback: &Option<Variant>) -> TokenStream {
+fn generate_enum(arb_int: TokenStream, enum_type: &Ident, match_arms: (Vec<TokenStream>, Vec<TokenStream>), fallback: Option<&Variant>) -> TokenStream {
     let (from_int_match_arms, to_int_match_arms) = match_arms;
 
     let const_ = if cfg!(feature = "nightly") {

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -1,29 +1,100 @@
 use proc_macro2::{TokenStream, Ident};
+use proc_macro_error::abort_call_site;
 use quote::quote;
-use syn::{DeriveInput, Data, Variant};
-use crate::shared::{self, unreachable, analyze_enum_derive, analyze_derive, generate_enum};
+use syn::{DeriveInput, Data, punctuated::Iter, Variant, Expr};
+use crate::shared::{self, BitSize, unreachable, EnumVariantValueAssigner, enum_fills_bitsize};
 
 pub(super) fn from_bits(item: TokenStream) -> TokenStream {
     let derive_input = parse(item);
-    let try_from = false;
-    let (derive_data, arb_int, name, internal_bitsize, derive_impl) = analyze_derive(&derive_input, try_from);
+    let (derive_data, arb_int, name, internal_bitsize, fallback) = analyze(&derive_input);
     let expanded = match derive_data {
         Data::Struct(_) => {
             generate_struct(arb_int, name)
         },
         Data::Enum(ref enum_data) => {
             let variants = enum_data.variants.iter();
-            let match_arms = analyze_enum_derive(variants, name, internal_bitsize, &derive_impl);
-            generate_enum(arb_int, name, match_arms, &derive_impl)
+            let match_arms = analyze_enum(variants, name, internal_bitsize, &fallback);
+            generate_enum(arb_int, name, match_arms, &fallback)
         },
         _ => unreachable(()),
     };
-    let fallback_variant = derive_impl.into_fallback_variant(); 
-    generate_common(expanded, name, fallback_variant)
+    generate_common(expanded, name, &fallback)
 }
 
 fn parse(item: TokenStream) -> DeriveInput {
     shared::parse_derive(item)
+}
+
+fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitSize, Option<Variant>) {
+    shared::analyze_derive(derive_input, false)
+}
+
+fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize, fallback: &Option<Variant>) -> (Vec<TokenStream>, Vec<TokenStream>) {
+    // in enums, internal_bitsize <= 64; u64::MAX + 1 = u128
+    
+    let enum_is_filled = enum_fills_bitsize(internal_bitsize, variants.len());
+    if !enum_is_filled && fallback.is_none() {
+        abort_call_site!("enum doesn't fill its bitsize"; help = "you need to use `#[derive(TryFromBits)]` instead, or specify one of the variants as #[fallback]")
+    }
+    if enum_is_filled && fallback.is_some() {
+        abort_call_site!("enum fills its bitsize but has fallback variant"; help = "remove `#[fallback]` from this enum")
+    }
+
+    let mut assigner = EnumVariantValueAssigner::new(internal_bitsize);
+
+    variants.map(|variant| {
+        let variant_name = &variant.ident;
+        let variant_value = assigner.assign(variant);
+
+        // might be useful for not generating "1u128 -> Self::Variant"
+        let variant_value: Expr = syn::parse_str(&variant_value.to_string()).unwrap_or_else(unreachable);
+
+        let from_int_match_arm = quote! {
+            #variant_value => Self::#variant_name,
+        };
+
+        let to_int_match_arm = quote! {
+            #name::#variant_name => Self::new(#variant_value),
+        };
+
+        (from_int_match_arm, to_int_match_arm)
+    }).unzip()
+}
+
+fn generate_enum(arb_int: TokenStream, enum_type: &Ident, match_arms: (Vec<TokenStream>, Vec<TokenStream>), fallback: &Option<Variant>) -> TokenStream {
+    let (from_int_match_arms, to_int_match_arms) = match_arms;
+
+    let const_ = if cfg!(feature = "nightly") {
+        quote!(const)
+    } else {
+        quote!()
+    };
+
+    let from_enum_impl = shared::generate_from_enum_impl(&arb_int, enum_type, to_int_match_arms, &const_);
+
+    let catch_all_arm = if let Some(variant) = fallback {
+        let fallback_name = &variant.ident;
+        quote! {
+            _ => Self::#fallback_name,
+        }
+    } else {
+        quote! {
+            // constness: unreachable!() is not const yet
+            _ => panic!("unreachable: arbitrary_int already validates that this is unreachable")
+        }
+    };
+
+    quote! {
+        impl #const_ ::core::convert::From<#arb_int> for #enum_type {
+            fn from(number: #arb_int) -> Self {
+                match number.value() {
+                    #( #from_int_match_arms )*
+                    #catch_all_arm
+                }
+            }
+        }
+        #from_enum_impl
+    }
 }
 
 fn generate_struct(arb_int: TokenStream, struct_type: &Ident) -> TokenStream {
@@ -47,7 +118,7 @@ fn generate_struct(arb_int: TokenStream, struct_type: &Ident) -> TokenStream {
     }
 }
 
-fn generate_common(expanded: TokenStream, type_name: &Ident, _fallback_variant: Option<Variant>) -> TokenStream {
+fn generate_common(expanded: TokenStream, type_name: &Ident, _fallback_variant: &Option<Variant>) -> TokenStream {
     // TODO: if fallback_variant.is_some(), an assert should not be generated
     quote! {
         #expanded

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -40,11 +40,11 @@ fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize
         abort_call_site!("enum fills its bitsize but has fallback variant"; help = "remove `#[fallback]` from this enum")
     }
 
-    let mut assigner = EnumVariantValueAssigner::new(internal_bitsize);
+    let mut value_assigner = EnumVariantValueAssigner::new(internal_bitsize);
 
     variants.map(|variant| {
         let variant_name = &variant.ident;
-        let variant_value = assigner.assign(variant);
+        let variant_value = value_assigner.assign(variant);
 
         // might be useful for not generating "1u128 -> Self::Variant"
         let variant_value: Expr = syn::parse_str(&variant_value.to_string()).unwrap_or_else(unreachable);

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -18,8 +18,8 @@ pub(super) fn from_bits(item: TokenStream) -> TokenStream {
         },
         _ => unreachable(()),
     };
-    let reserved_variant = derive_impl.into_reserved_variant(); 
-    generate_common(expanded, name, reserved_variant)
+    let fallback_variant = derive_impl.into_fallback_variant(); 
+    generate_common(expanded, name, fallback_variant)
 }
 
 fn parse(item: TokenStream) -> DeriveInput {
@@ -47,8 +47,8 @@ fn generate_struct(arb_int: TokenStream, struct_type: &Ident) -> TokenStream {
     }
 }
 
-fn generate_common(expanded: TokenStream, type_name: &Ident, _reserved_variant: Option<Variant>) -> TokenStream {
-    // TODO: if reserved_variant.is_some(), an assert should not be generated
+fn generate_common(expanded: TokenStream, type_name: &Ident, _fallback_variant: Option<Variant>) -> TokenStream {
+    // TODO: if fallback_variant.is_some(), an assert should not be generated
     quote! {
         #expanded
 

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -1,61 +1,29 @@
 use proc_macro2::{TokenStream, Ident};
 use quote::quote;
-use syn::{DeriveInput, Data, punctuated::Iter, Variant};
-
-use crate::shared::{self, BitSize, unreachable};
+use syn::{DeriveInput, Data, Variant};
+use crate::shared::{self, unreachable, analyze_enum_derive, analyze_derive, generate_enum};
 
 pub(super) fn from_bits(item: TokenStream) -> TokenStream {
     let derive_input = parse(item);
-    let (derive_data, arb_int, name, internal_bitsize) = analyze(&derive_input);
+    let try_from = false;
+    let (derive_data, arb_int, name, internal_bitsize, derive_impl) = analyze_derive(&derive_input, try_from);
     let expanded = match derive_data {
         Data::Struct(_) => {
             generate_struct(arb_int, name)
         },
         Data::Enum(ref enum_data) => {
             let variants = enum_data.variants.iter();
-            let match_arms = analyze_enum(variants, name, internal_bitsize);
-            generate_enum(arb_int, name, match_arms)
+            let match_arms = analyze_enum_derive(variants, name, internal_bitsize, &derive_impl);
+            generate_enum(arb_int, name, match_arms, &derive_impl)
         },
         _ => unreachable(()),
     };
-    generate_common(expanded, name)
+    let reserved_variant = derive_impl.into_reserved_variant(); 
+    generate_common(expanded, name, reserved_variant)
 }
 
 fn parse(item: TokenStream) -> DeriveInput {
     shared::parse_derive(item)
-}
-
-fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitSize) {
-    shared::analyze_derive(derive_input, false)
-}
-
-fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize) -> (Vec<TokenStream>, Vec<TokenStream>) {
-    shared::analyze_enum_derive(variants, name, internal_bitsize, false)
-}
-
-fn generate_enum(arb_int: TokenStream, enum_type: &Ident, match_arms: (Vec<TokenStream>, Vec<TokenStream>)) -> TokenStream {
-    let (from_int_match_arms, to_int_match_arms) = match_arms;
-
-    let const_ = if cfg!(feature = "nightly") {
-        quote!(const)
-    } else {
-        quote!()
-    };
-
-    let from_enum_impl = shared::generate_from_enum_impl(&arb_int, enum_type, to_int_match_arms, &const_);
-
-    quote! {
-        impl #const_ ::core::convert::From<#arb_int> for #enum_type {
-            fn from(number: #arb_int) -> Self {
-                match number.value() {
-                    #( #from_int_match_arms )*
-                    // constness: unreachable!() is not const yet
-                    _ => panic!("unreachable: arbitrary_int already validates that this is unreachable")
-                }
-            }
-        }
-        #from_enum_impl
-    }
 }
 
 fn generate_struct(arb_int: TokenStream, struct_type: &Ident) -> TokenStream {
@@ -79,7 +47,8 @@ fn generate_struct(arb_int: TokenStream, struct_type: &Ident) -> TokenStream {
     }
 }
 
-fn generate_common(expanded: TokenStream, type_name: &Ident) -> TokenStream {
+fn generate_common(expanded: TokenStream, type_name: &Ident, _reserved_variant: Option<Variant>) -> TokenStream {
+    // TODO: if reserved_variant.is_some(), an assert should not be generated
     quote! {
         #expanded
 

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -30,8 +30,6 @@ fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitS
 }
 
 fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize, fallback: Option<&Variant>) -> (Vec<TokenStream>, Vec<TokenStream>) {
-    // in enums, internal_bitsize <= 64; u64::MAX + 1 = u128
-    
     let enum_is_filled = enum_fills_bitsize(internal_bitsize, variants.len());
     if !enum_is_filled && fallback.is_none() {
         abort_call_site!("enum doesn't fill its bitsize"; help = "you need to use `#[derive(TryFromBits)]` instead, or specify one of the variants as #[fallback]")

--- a/bilge-impl/src/lib.rs
+++ b/bilge-impl/src/lib.rs
@@ -34,7 +34,7 @@ pub fn bitsize_internal(args: TokenStream, item: TokenStream) -> TokenStream {
 /// This should be used when your enum or enums nested in
 /// a struct don't fill their given `bitsize`.
 #[proc_macro_error]
-#[proc_macro_derive(TryFromBits, attributes(bitsize_internal, reserved))]
+#[proc_macro_derive(TryFromBits, attributes(bitsize_internal, fallback))]
 pub fn derive_try_from_bits(item: TokenStream) -> TokenStream {
     try_from_bits::try_from_bits(item.into()).into()
 }
@@ -45,7 +45,7 @@ pub fn derive_try_from_bits(item: TokenStream) -> TokenStream {
 /// a struct fill their given `bitsize` or if you're not
 /// using enums.
 #[proc_macro_error]
-#[proc_macro_derive(FromBits, attributes(bitsize_internal, reserved))]
+#[proc_macro_derive(FromBits, attributes(bitsize_internal, fallback))]
 pub fn derive_from_bits(item: TokenStream) -> TokenStream {
     from_bits::from_bits(item.into()).into()
 }

--- a/bilge-impl/src/lib.rs
+++ b/bilge-impl/src/lib.rs
@@ -34,7 +34,7 @@ pub fn bitsize_internal(args: TokenStream, item: TokenStream) -> TokenStream {
 /// This should be used when your enum or enums nested in
 /// a struct don't fill their given `bitsize`.
 #[proc_macro_error]
-#[proc_macro_derive(TryFromBits, attributes(bitsize_internal))]
+#[proc_macro_derive(TryFromBits, attributes(bitsize_internal, reserved))]
 pub fn derive_try_from_bits(item: TokenStream) -> TokenStream {
     try_from_bits::try_from_bits(item.into()).into()
 }
@@ -45,7 +45,7 @@ pub fn derive_try_from_bits(item: TokenStream) -> TokenStream {
 /// a struct fill their given `bitsize` or if you're not
 /// using enums.
 #[proc_macro_error]
-#[proc_macro_derive(FromBits, attributes(bitsize_internal))]
+#[proc_macro_derive(FromBits, attributes(bitsize_internal, reserved))]
 pub fn derive_from_bits(item: TokenStream) -> TokenStream {
     from_bits::from_bits(item.into()).into()
 }

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{TokenStream, Ident};
 use proc_macro_error::{abort_call_site, emit_call_site_warning, abort};
 use quote::{ToTokens, quote};
-use syn::{DeriveInput, LitInt, Expr, punctuated::Iter, Variant, Type, Lit, ExprLit, Meta};
+use syn::{DeriveInput, LitInt, Expr, punctuated::Iter, Variant, Type, Lit, ExprLit, Meta, Data, Attribute};
 
 /// As arbitrary_int is limited to basic rust primitives, the maximum is u128.
 /// Is there a true usecase for bitfields above this size?
@@ -15,7 +15,7 @@ pub(crate) fn parse_derive(item: TokenStream) -> DeriveInput {
 
 // allow since we want `if try_from` blocks to stand out
 #[allow(clippy::collapsible_if)]
-pub(crate) fn analyze_derive(derive_input: &DeriveInput, try_from: bool) -> (&syn::Data, TokenStream, &Ident, BitSize) {
+pub(crate) fn analyze_derive(derive_input: &DeriveInput, try_from: bool) -> (&syn::Data, TokenStream, &Ident, BitSize, DeriveImpl) {
     let DeriveInput { 
         attrs,
         ident,
@@ -25,21 +25,31 @@ pub(crate) fn analyze_derive(derive_input: &DeriveInput, try_from: bool) -> (&sy
     } = derive_input;
 
     if !try_from {
-        if attrs.iter().any(|attr| 
-            matches!(&attr.meta, Meta::Path(path) if path.to_token_stream().to_string().contains("non_exhaustive"))
-        ) {
+        if attrs.iter().any(is_non_exhaustive_attribute) {
             abort_call_site!("Item can't be FromBits and non_exhaustive"; help = "remove #[non_exhaustive] or derive(FromBits) here")
         }
     } else {
         // currently not allowed, would need some thinking:
         if let syn::Data::Struct(_) = data {
-            if attrs.iter().any(|attr| 
-                matches!(&attr.meta, Meta::Path(path) if path.to_token_stream().to_string().contains("non_exhaustive"))
-            ) {
+            if attrs.iter().any(is_non_exhaustive_attribute) {
                 abort_call_site!("Using #[non_exhaustive] on structs is currently not supported"; help = "open an issue on our repository if needed")
             }
         }
     }
+
+    let derive_impl = match reserved_variant(data) {
+        None if try_from => DeriveImpl::TryFrom,
+        Some(_) if try_from => {
+            emit_call_site_warning!(
+                "enum defines reserved variant"; 
+                help = "use `#[derive(FromBits)]` instead. a `From` implementation can be genereated from the reserved variant"
+            );
+            DeriveImpl::TryFrom
+        }
+        Some(variant) => DeriveImpl::FromWithReservedVariant(variant),
+        None => DeriveImpl::From,
+    };
+
     // parsing the #[bitsize_internal(num)] attribute macro
     let args = attrs.iter().find_map(|attr| {
         if attr.to_token_stream().to_string().contains("bitsize_internal") {
@@ -54,7 +64,7 @@ pub(crate) fn analyze_derive(derive_input: &DeriveInput, try_from: bool) -> (&sy
     }).unwrap_or_else(|| abort_call_site!("add #[bitsize] attribute above your derive attribute"));
     let (bitsize, arb_int) = bitsize_and_arbitrary_int_from(args);
 
-    (data, arb_int, ident, bitsize)
+    (data, arb_int, ident, bitsize, derive_impl)
 }
 
 // If we want to support bitsize(u4) besides bitsize(4), do that here.
@@ -91,25 +101,14 @@ pub fn generate_type_bitsize(ty: &Type) -> TokenStream {
     }
 }
 
-// allow since we want `if try_from` blocks to stand out
-#[allow(clippy::collapsible_else_if)]
-pub(crate) fn analyze_enum_derive(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize, try_from: bool) -> (Vec<TokenStream>, Vec<TokenStream>) {
+pub(crate) fn analyze_enum_derive(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize, derive_impl: &DeriveImpl) -> (Vec<TokenStream>, Vec<TokenStream>) {
     let variants_count = variants.len();
     // in enums, internal_bitsize <= 64; u64::MAX + 1 = u128
     let max_variants_count = 1u128 << internal_bitsize;
-
-    // Verify if the enum fills its bitsize, depending on which derive impl we are in.
+    
     // Verifying that the value doesn't exceed max_variants_count is done further down.
-    if try_from {
-        if variants_count as u128 == max_variants_count {
-            emit_call_site_warning!("enum fills its bitsize"; help = "you can use `#[derive(FromBits)]` instead, rust will provide `TryFrom` for you (so you don't necessarily have to update call-sites)");
-        }
-    } else {
-        // semantically the same as #[non_exhaustive]
-        if variants_count as u128 != max_variants_count {
-            abort_call_site!("enum doesn't fill its bitsize"; help = "you need to use `#[derive(TryFromBits)]` instead")
-        }
-    }    
+    let enum_fills_bitsize = variants_count as u128 == max_variants_count;
+    validate_bitsize(derive_impl, enum_fills_bitsize);  
 
     let mut next_variant_value = 0;
     variants.map(|variant| {
@@ -136,11 +135,11 @@ pub(crate) fn analyze_enum_derive(variants: Iter<Variant>, name: &Ident, interna
         // might be useful for not generating "1u128 -> Self::Variant"
         let variant_value: Expr = syn::parse_str(&variant_value.to_string()).unwrap_or_else(unreachable);
 
-        let from_int_match_arm = if try_from {
+        let from_int_match_arm = if matches!(derive_impl, DeriveImpl::TryFrom) {
             quote! {
                 #variant_value => Ok(Self::#variant_name),
             }
-        }  else {
+        } else {
             quote! {
                 #variant_value => Self::#variant_name,
             }
@@ -154,6 +153,41 @@ pub(crate) fn analyze_enum_derive(variants: Iter<Variant>, name: &Ident, interna
     }).unzip()
 }
 
+/// Verify if the enum fills its bitsize, depending on which derive impl we are in.
+fn validate_bitsize(derive_impl: &DeriveImpl, enum_fills_bitsize: bool) {
+    match derive_impl {
+        DeriveImpl::TryFrom if enum_fills_bitsize => {
+            emit_call_site_warning!("enum fills its bitsize"; help = "you can use `#[derive(FromBits)]` instead, rust will provide `TryFrom` for you (so you don't necessarily have to update call-sites)");
+        },
+        DeriveImpl::FromWithReservedVariant(_) if enum_fills_bitsize => {
+            emit_call_site_warning!("enum fills its bitsize but has reserved variant"; help = "you can remove the #[reserved] attribute`");
+        },
+        DeriveImpl::From if !enum_fills_bitsize => {
+            // semantically the same as #[non_exhaustive]
+            abort_call_site!("enum doesn't fill its bitsize"; help = "you need to use `#[derive(TryFromBits)]` instead, or specify one of the variants as #[reserved]")
+        },
+        _ => (),
+    }
+}
+
+pub(crate) fn generate_enum(arb_int: TokenStream, enum_type: &Ident, match_arms: (Vec<TokenStream>, Vec<TokenStream>), derive_impl: &DeriveImpl) -> TokenStream {
+    let (from_int_match_arms, to_int_match_arms) = match_arms;
+
+    let const_ = if cfg!(feature = "nightly") {
+        quote!(const)
+    } else {
+        quote!()
+    };
+
+    let from_enum_impl = generate_from_enum_impl(&arb_int, enum_type, to_int_match_arms, &const_);
+    let to_enum_impl = generate_to_enum_impl(&arb_int, enum_type, from_int_match_arms, &const_, derive_impl);
+
+    quote! {
+        #from_enum_impl
+        #to_enum_impl
+    }
+}
+
 pub(crate) fn generate_from_enum_impl(arb_int: &TokenStream, enum_type: &Ident, to_int_match_arms: Vec<TokenStream>, const_: &TokenStream) -> TokenStream {
     quote! {
         impl #const_ ::core::convert::From<#enum_type> for #arb_int {
@@ -163,6 +197,51 @@ pub(crate) fn generate_from_enum_impl(arb_int: &TokenStream, enum_type: &Ident, 
                 }
             }
         }
+    }
+}
+
+fn generate_to_enum_impl(arb_int: &TokenStream, enum_type: &Ident, from_int_match_arms: Vec<TokenStream>, const_: &TokenStream, derive_impl: &DeriveImpl) -> TokenStream {
+    match derive_impl {
+        DeriveImpl::From => {
+            quote! {
+                impl #const_ ::core::convert::From<#arb_int> for #enum_type {
+                    fn from(number: #arb_int) -> Self {
+                        match number.value() {
+                            #( #from_int_match_arms )*
+                            // constness: unreachable!() is not const yet
+                            _ => panic!("unreachable: arbitrary_int already validates that this is unreachable")
+                        }
+                    }
+                }
+            } 
+        },
+        DeriveImpl::FromWithReservedVariant(reserved) => {
+            let reserved_name = &reserved.ident;
+            quote! {
+                impl #const_ ::core::convert::From<#arb_int> for #enum_type {
+                    fn from(number: #arb_int) -> Self {
+                        match number.value() {
+                            #( #from_int_match_arms )*
+                            _ => Self::#reserved_name
+                        }
+                    }
+                }
+            }
+        },
+        DeriveImpl::TryFrom => {
+            quote! {
+                impl #const_ ::core::convert::TryFrom<#arb_int> for #enum_type {
+                    type Error = #arb_int;
+    
+                    fn try_from(number: #arb_int) -> ::core::result::Result<Self, Self::Error> {
+                        match number.value() {
+                            #( #from_int_match_arms )*
+                            i => Err(#arb_int::new(i)),
+                        }
+                    }
+                }
+            }
+        },
     }
 }
 
@@ -180,4 +259,64 @@ pub fn is_always_filled(ty: &Type) -> bool {
 #[inline]
 pub fn unreachable<T, U>(_: T) -> U {
     unreachable!("should have already been validated")
+}
+
+fn reserved_variant(data: &Data) -> Option<Variant> {
+    match data {
+        Data::Enum(enum_data) => {
+            let mut variants_with_reserved = enum_data
+                .variants
+                .iter()
+                .filter(|variant| variant.attrs.iter().any(is_reserved_attribute));
+
+            let variant = variants_with_reserved.next();
+
+            if variants_with_reserved.next().is_some() {
+                abort_call_site!("only one enum variant may be reserved"; help = "remove #[reserved] attributes until you only have one");
+            } else {
+                variant.cloned()
+            }
+        }
+        Data::Struct(struct_data) => {
+            let mut field_attrs = struct_data.fields.iter().flat_map(|field| &field.attrs);
+            
+            if field_attrs.any(is_reserved_attribute) {
+                abort_call_site!("the attribute `reserved` is only applicable to enums"; help = "remove all `#[reserved]` from this struct")
+            } else {
+                None
+            }
+        }
+        _ => unreachable(())
+    }
+}
+
+pub fn is_attribute(attr: &Attribute, name: &str) -> bool {
+    if let Meta::Path(path) = &attr.meta {
+        path.is_ident(name)
+    } else {
+        false
+    }
+}
+
+fn is_non_exhaustive_attribute(attr: &Attribute) -> bool {
+    is_attribute(attr, "non_exhaustive")
+}
+
+fn is_reserved_attribute(attr: &Attribute) -> bool {
+    is_attribute(attr, "reserved")
+}
+
+pub(crate) enum DeriveImpl {
+    From,
+    FromWithReservedVariant(Variant),
+    TryFrom,
+}
+
+impl DeriveImpl {
+    pub fn into_reserved_variant(self) -> Option<Variant> {
+        match self {
+            DeriveImpl::FromWithReservedVariant(reserved) => Some(reserved),
+            _ => None,
+        }
+    }
 }

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -115,6 +115,7 @@ pub fn is_always_filled(ty: &Type) -> bool {
     ty.starts_with('u') || ty == "bool"
 }
 
+/// in enums, internal_bitsize <= 64; u64::MAX + 1 = u128
 pub fn enum_fills_bitsize(bitsize: u8, variants_count: usize) -> bool {
     let max_variants_count = 2u128.saturating_pow(bitsize as u32);
     variants_count as u128 == max_variants_count

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -116,8 +116,9 @@ pub fn is_always_filled(ty: &Type) -> bool {
 }
 
 /// in enums, internal_bitsize <= 64; u64::MAX + 1 = u128
+/// therefore the bitshift would not overflow.
 pub fn enum_fills_bitsize(bitsize: u8, variants_count: usize) -> bool {
-    let max_variants_count = 2u128.saturating_pow(bitsize as u32);
+    let max_variants_count = 1u128 << bitsize;
     variants_count as u128 == max_variants_count
 }
 
@@ -182,7 +183,7 @@ impl EnumVariantValueAssigner {
     }
     
     fn max_value(&self) -> u128 {
-        2u128.saturating_pow(self.bitsize as u32) - 1
+        (1u128 << self.bitsize) - 1
     }
 
     fn value_from_discriminant(&self, variant: &Variant) -> Option<u128> {

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -290,6 +290,21 @@ fn reserved_variant(data: &Data) -> Option<Variant> {
     }
 }
 
+pub(crate) enum DeriveImpl {
+    From,
+    FromWithReservedVariant(Variant),
+    TryFrom,
+}
+
+impl DeriveImpl {
+    pub fn into_reserved_variant(self) -> Option<Variant> {
+        match self {
+            DeriveImpl::FromWithReservedVariant(reserved) => Some(reserved),
+            _ => None,
+        }
+    }
+}
+
 pub fn is_attribute(attr: &Attribute, name: &str) -> bool {
     if let Meta::Path(path) = &attr.meta {
         path.is_ident(name)
@@ -304,19 +319,4 @@ fn is_non_exhaustive_attribute(attr: &Attribute) -> bool {
 
 fn is_reserved_attribute(attr: &Attribute) -> bool {
     is_attribute(attr, "reserved")
-}
-
-pub(crate) enum DeriveImpl {
-    From,
-    FromWithReservedVariant(Variant),
-    TryFrom,
-}
-
-impl DeriveImpl {
-    pub fn into_reserved_variant(self) -> Option<Variant> {
-        match self {
-            DeriveImpl::FromWithReservedVariant(reserved) => Some(reserved),
-            _ => None,
-        }
-    }
 }

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -25,7 +25,7 @@ fn parse(item: TokenStream) -> DeriveInput {
     shared::parse_derive(item)
 }
 
-fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitSize, Option<Variant>) {
+fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitSize, Option<&Variant>) {
     shared::analyze_derive(derive_input, true)
 }
 
@@ -35,11 +35,11 @@ fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize
         emit_call_site_warning!("enum fills its bitsize"; help = "you can use `#[derive(FromBits)]` instead, rust will provide `TryFrom` for you (so you don't necessarily have to update call-sites)");
     } 
 
-    let mut assigner = EnumVariantValueAssigner::new(internal_bitsize);
+    let mut value_assigner = EnumVariantValueAssigner::new(internal_bitsize);
     
     variants.map(|variant| {
         let variant_name = &variant.ident;
-        let variant_value = assigner.assign(variant);
+        let variant_value = value_assigner.assign(variant);
 
         // might be useful for not generating "1u128 -> Self::Variant"
         let variant_value: Expr = syn::parse_str(&variant_value.to_string()).unwrap_or_else(unreachable);

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -1,20 +1,21 @@
 use proc_macro2::{TokenStream, Ident};
 use quote::quote;
-use syn::{DeriveInput, Data, punctuated::Iter, Variant, Type, Fields};
+use syn::{DeriveInput, Data, Type, Fields};
 
-use crate::shared::{self, BitSize, unreachable};
+use crate::shared::{self, unreachable, analyze_enum_derive, analyze_derive, generate_enum};
 
 pub(super) fn try_from_bits(item: TokenStream) -> TokenStream {
     let derive_input = parse(item);
-    let (derive_data, arb_int, name, internal_bitsize) = analyze(&derive_input);
+    let try_from = true;
+    let (derive_data, arb_int, name, internal_bitsize, derive_impl) = analyze_derive(&derive_input, try_from);
     match derive_data {
         Data::Struct(ref data) => {
             codegen_struct(arb_int, name, &data.fields)
         },
         Data::Enum(ref enum_data) => {
             let variants = enum_data.variants.iter();
-            let match_arms = analyze_enum(variants, name, internal_bitsize);
-            codegen_enum(arb_int, name, match_arms)
+            let match_arms = analyze_enum_derive(variants, name, internal_bitsize, &derive_impl);
+            generate_enum(arb_int, name, match_arms, &derive_impl)
         },
         _ => unreachable(()),
     }
@@ -22,41 +23,6 @@ pub(super) fn try_from_bits(item: TokenStream) -> TokenStream {
 
 fn parse(item: TokenStream) -> DeriveInput {
     shared::parse_derive(item)
-}
-
-fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitSize) {
-    shared::analyze_derive(derive_input, true)
-}
-
-fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize) -> (Vec<TokenStream>, Vec<TokenStream>) {
-    shared::analyze_enum_derive(variants, name, internal_bitsize, true)
-}
-
-fn codegen_enum(arb_int: TokenStream, enum_type: &Ident, match_arms: (Vec<TokenStream>, Vec<TokenStream>)) -> TokenStream {
-    let (from_int_match_arms, to_int_match_arms) = match_arms;
-
-    let const_ = if cfg!(feature = "nightly") {
-        quote!(const)
-    } else {
-        quote!()
-    };
-
-    let from_enum_impl = shared::generate_from_enum_impl(&arb_int, enum_type, to_int_match_arms, &const_);
-    quote! {
-        impl #const_ ::core::convert::TryFrom<#arb_int> for #enum_type {
-            type Error = #arb_int;
-
-            fn try_from(number: #arb_int) -> ::core::result::Result<Self, Self::Error> {
-                match number.value() {
-                    #( #from_int_match_arms )*
-                    i => Err(#arb_int::new(i)),
-                }
-            }
-        }
-
-        // this other direction is needed for get/set/new
-        #from_enum_impl
-    }
 }
 
 fn generate_field_check(ty: &Type) -> TokenStream {

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -30,7 +30,6 @@ fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitS
 }
 
 fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize) -> (Vec<TokenStream>, Vec<TokenStream>) {
-    // in enums, internal_bitsize <= 64; u64::MAX + 1 = u128
     if enum_fills_bitsize(internal_bitsize, variants.len()) {
         emit_call_site_warning!("enum fills its bitsize"; help = "you can use `#[derive(FromBits)]` instead, rust will provide `TryFrom` for you (so you don't necessarily have to update call-sites)");
     } 


### PR DESCRIPTION
Resolves #24.
Currently, enums which don't fill their bitfield don't allow deriving `FromBits`. This PR allows adding a `#[reserved]` attribute to one (and only one) variant of such enums:
```rust
#[bitsize(3)]
#[derive(FromBits)]
enum Opcode {
    Add = 0b001,
    Sub = 0b010,
    Mul = 0b011,
    #[reserved]
    Reserved,
}
```

This will then generate a `_ => Self::Reserved` arm in the `From<int>` implementation. This is is a followup from the reddit thread, where I realized this feature could be useful to me. 

Please note that **this is a WIP**: for example, this trips the generated `assert!(#type_name::FILLED)` check, and so the generated code fails to compile. I wanted to see if this PR aligns with what you want this crate to look like, before attempting to change that assert.

I'm open to any changes or suggestions. Thanks for making this crate.