### PR TITLE
validate enum variants are units

### DIFF
--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -38,6 +38,8 @@ fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize
         abort_call_site!("enum fills its bitsize but has fallback variant"; help = "remove `#[fallback]` from this enum")
     }
 
+    shared::validate_enum_variants(variants.clone());
+
     let mut value_assigner = EnumVariantValueAssigner::new(internal_bitsize);
 
     variants.map(|variant| {

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -30,6 +30,8 @@ fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitS
 }
 
 fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize, fallback: Option<&Variant>) -> (Vec<TokenStream>, Vec<TokenStream>) {
+    shared::validate_enum_variants(variants.clone());
+    
     let enum_is_filled = enum_fills_bitsize(internal_bitsize, variants.len());
     if !enum_is_filled && fallback.is_none() {
         abort_call_site!("enum doesn't fill its bitsize"; help = "you need to use `#[derive(TryFromBits)]` instead, or specify one of the variants as #[fallback]")
@@ -37,8 +39,6 @@ fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize
     if enum_is_filled && fallback.is_some() {
         abort_call_site!("enum fills its bitsize but has fallback variant"; help = "remove `#[fallback]` from this enum")
     }
-
-    shared::validate_enum_variants(variants.clone());
 
     let mut value_assigner = EnumVariantValueAssigner::new(internal_bitsize);
 

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -1,7 +1,8 @@
 use proc_macro2::{TokenStream, Ident};
 use proc_macro_error::{abort_call_site, abort};
 use quote::{ToTokens, quote};
-use syn::{DeriveInput, LitInt, Expr, Variant, Type, Lit, ExprLit, Meta, Data, Attribute};
+use syn::punctuated::Iter;
+use syn::{DeriveInput, LitInt, Expr, Variant, Type, Lit, ExprLit, Meta, Data, Attribute, Fields};
 
 /// As arbitrary_int is limited to basic rust primitives, the maximum is u128.
 /// Is there a true usecase for bitfields above this size?
@@ -211,5 +212,13 @@ impl EnumVariantValueAssigner {
         let value = self.value_from_discriminant(variant).unwrap_or(self.next_expected_assignment);
         self.next_expected_assignment = value + 1;
         value
+    }
+}
+
+pub fn validate_enum_variants(variants: Iter<Variant>) {
+    for variant in variants {
+        if !matches!(variant.fields, Fields::Unit) {
+            abort!(variant, "currently, only unit variants are allowed in enums"; help = "change this variant to a unit");
+        }
     }
 }

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -30,11 +30,11 @@ fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitS
 }
 
 fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize) -> (Vec<TokenStream>, Vec<TokenStream>) {
+    shared::validate_enum_variants(variants.clone());
+
     if enum_fills_bitsize(internal_bitsize, variants.len()) {
         emit_call_site_warning!("enum fills its bitsize"; help = "you can use `#[derive(FromBits)]` instead, rust will provide `TryFrom` for you (so you don't necessarily have to update call-sites)");
     } 
-
-    shared::validate_enum_variants(variants.clone());
 
     let mut value_assigner = EnumVariantValueAssigner::new(internal_bitsize);
     

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -34,6 +34,8 @@ fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize
         emit_call_site_warning!("enum fills its bitsize"; help = "you can use `#[derive(FromBits)]` instead, rust will provide `TryFrom` for you (so you don't necessarily have to update call-sites)");
     } 
 
+    shared::validate_enum_variants(variants.clone());
+
     let mut value_assigner = EnumVariantValueAssigner::new(internal_bitsize);
     
     variants.map(|variant| {


### PR DESCRIPTION
Fixes #41.

I decided to perform the check in `analyze_enum()` of each derive instead of in `shared::analyze_derive()`.

Technically we can also support empty struct variants and empty tuple variants (that would require changing the derive codegen). For now I made unit variants a requirement.