### PR TITLE
Rollup of minor changes

### DIFF
--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -90,9 +90,6 @@ fn parse(item: TokenStream, args: TokenStream) -> (Item, BitSize) {
     }
     
     let (declared_bitsize, _arb_int) = shared::bitsize_and_arbitrary_int_from(args);
-    if declared_bitsize > shared::MAX_STRUCT_BIT_SIZE {
-        abort_call_site!("attribute is not a valid number"; help = "currently, numbers from 1 to {} are allowed", shared::MAX_STRUCT_BIT_SIZE)
-    }
     (item, declared_bitsize)
 }
 

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -228,6 +228,13 @@ fn modify_special_field_names(fields: &mut Fields) {
 }
 
 fn analyze_struct(fields: &Fields) -> TokenStream {
+    if matches!(fields, Fields::Named(fields) if fields.named.is_empty())
+        || matches!(fields, Fields::Unnamed(fields) if fields.unnamed.is_empty())
+        || matches!(fields, Fields::Unit) 
+    {
+        abort_call_site!("structs without fields are not supported")
+    }
+
     // NEVER move this, since we validate all nested field types here as well.
     // If we do want to move this, add a new function just for validation.
     fields.iter()
@@ -238,16 +245,21 @@ fn analyze_struct(fields: &Fields) -> TokenStream {
 }
 
 fn analyze_enum(bitsize: BitSize, variants: Iter<Variant>) -> TokenStream {
+    let variant_count = variants.clone().count();
+    if variant_count == 0 {
+        abort_call_site!("empty enums are not supported");
+    }
+
     if bitsize > MAX_ENUM_BIT_SIZE {
-        abort_call_site!("enum bitsize is limited to 64")
+        abort_call_site!("enum bitsize is limited to {}", MAX_ENUM_BIT_SIZE)
     }
     
-    let has_fallback = variants.clone().flat_map(|variant| &variant.attrs).any(is_fallback_attribute);
+    let has_fallback = variants.flat_map(|variant| &variant.attrs).any(is_fallback_attribute);
     
     if has_fallback {
         quote!(true)
     } else {
-        let enum_is_filled = enum_fills_bitsize(bitsize, variants.count());
+        let enum_is_filled = enum_fills_bitsize(bitsize, variant_count);
         quote!(#enum_is_filled)    
     }
 }

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -210,21 +210,20 @@ fn modify_special_field_names(fields: &mut Fields) {
     // Also, it might be useful to generate no getters or setters for these fields and skipping some calc.
     let mut reserved_count = 0;
     let mut padding_count = 0;
-    fields.iter_mut().for_each(|f| {
-        if let Some(name) = &mut f.ident {
-            if name == "reserved" || name == "_reserved" {
-                reserved_count += 1;
-                let span = name.span();
-                let name = format!("reserved_{}", "i".repeat(reserved_count));
-                f.ident = Some(Ident::new(&name, span))
-            } else if name == "padding" || name == "_padding" {
-                padding_count += 1;
-                let span = name.span();
-                let name = format!("padding_{}", "i".repeat(padding_count));
-                f.ident = Some(Ident::new(&name, span))
-            }
+    let field_idents_mut = fields.iter_mut().filter_map(|field| field.ident.as_mut());
+    for ident in field_idents_mut {
+        if ident == "reserved" || ident == "_reserved" {
+            reserved_count += 1;
+            let span = ident.span();
+            let name = format!("reserved_{}", "i".repeat(reserved_count));
+            *ident = Ident::new(&name, span)
+        } else if ident == "padding" || ident == "_padding" {
+            padding_count += 1;
+            let span = ident.span();
+            let name = format!("padding_{}", "i".repeat(padding_count));
+            *ident = Ident::new(&name, span)
         }
-    });
+    }
 }
 
 fn analyze_struct(fields: &Fields) -> TokenStream {

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -227,10 +227,7 @@ fn modify_special_field_names(fields: &mut Fields) {
 }
 
 fn analyze_struct(fields: &Fields) -> TokenStream {
-    if matches!(fields, Fields::Named(fields) if fields.named.is_empty())
-        || matches!(fields, Fields::Unnamed(fields) if fields.unnamed.is_empty())
-        || matches!(fields, Fields::Unit) 
-    {
+    if fields.is_empty() {
         abort_call_site!("structs without fields are not supported")
     }
 

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -66,9 +66,11 @@ pub fn bitsize_and_arbitrary_int_from(bitsize_arg: TokenStream) -> (BitSize, Tok
         abort!(bitsize_arg, "attribute value is not a number"; help = "you need to define the size like this: `#[bitsize(32)]`")
     );
     // without postfix
-    let bitsize = bitsize.base10_parse().unwrap_or_else(|_|
-        abort!(bitsize_arg, "attribute value is not a valid number"; help = "currently, numbers from 1 to {} are allowed", MAX_STRUCT_BIT_SIZE)
-    );
+    let bitsize = bitsize
+        .base10_parse()
+        .ok()
+        .filter(|&n| n != 0 && n <= MAX_STRUCT_BIT_SIZE)
+        .unwrap_or_else(|| abort!(bitsize_arg, "attribute value is not a valid number"; help = "currently, numbers from 1 to {} are allowed", MAX_STRUCT_BIT_SIZE));
     let arb_int = syn::parse_str(&format!("u{bitsize}")).unwrap_or_else(unreachable);
     (bitsize, arb_int)
 }

--- a/examples/nested_tuples_and_arrays.rs
+++ b/examples/nested_tuples_and_arrays.rs
@@ -36,10 +36,6 @@ enum HaveFun {
 #[derive(Clone, Copy, FromBits, DebugBits, PartialEq)]
 struct InnerTupleStruct(u1, bool);
 
-#[bitsize(2)]
-#[derive(TryFromBits)]
-enum Empty {}
-
 #[bitsize(54)]
 #[derive(FromBits, DebugBits, PartialEq)]
 struct Basic {


### PR DESCRIPTION
Just fairly inconsequential things that probably don't deserve their own issue (but I will create issues if that's what we want!):
1. `0` was not immediately rejected in `#[bitsize]`, which emits the error "cannot find type `u0` in this scope" or something else if the user happens to have a `u0` defined
2. we don't reject empty enums, unit structs and empty tuple/named structs. for structs, this prevents compilation and emits a message about a semicolon (because in `bitsize_internal::generate_struct()`, `#constructor_parts` expands to nothing)
3. by iterating over a the inner value of an `Option`, we save an indentation level. yep.