### PR TITLE
Add basic(-ally all) tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ ise.set_val_0_at(2, ise5);
 assert_eq!(0b0000_0000_0000_0000_0000_0000_0001_0100, ise.value);
 ```
 
-Depending on what you're working with, there might be enum-based values with a lot of reserved variants.
-You can define those like this:
+Depending on what you're working with, only a subset of enum values might be clear, or some values might be reserved.
+In that case, you can use a fallback variant, defined like this:
 
 ```rust
 #[bitsize(32)]
@@ -137,18 +137,26 @@ which will convert any undeclared bits to `Reserved`:
 
 ```rust
 assert_eq!(Subclass::Reserved, Subclass::from(3));
+assert_eq!(Subclass::Reserved, Subclass::from(42));
+let num = u32::from(Subclass::from(42));
+assert_eq!(3, num);
+assert_ne!(42, num);
 ```
 
-but caution: you won't be able to retrieve the exact number again!
+or, if you need to keep the exact number saved, use:
 
 ```rust
-let subclass = Subclass::from(42);
-let num = u32::from(subclass);
-assert_ne!(42, num);
-assert_eq!(3, num);
+#[fallback]
+Reserved(u32),
 ```
 
-We'll enable that usecase later.
+```rust
+assert_eq!(Subclass2::Reserved(3), Subclass2::from(3));
+assert_eq!(Subclass2::Reserved(42), Subclass2::from(42));
+let num = u32::from(Subclass2::from(42));
+assert_eq!(42, num);
+assert_ne!(3, num);
+```
 
 ### Fallible (TryFrom)
 
@@ -203,6 +211,8 @@ Ok(Device { reserved_i: 0, class: Stationary, reserved_ii: 0 })
 Device { reserved_i: 0, class: Mobile, reserved_ii: 0 }
 ```
 
+For testing + overview, the full readme example code is in `/examples/readme.rs`.
+
 ### Custom -Bits derives
 
 One of the main advantages of our approach is that we can keep `#[bitsize]` pretty slim, offloading all the other features to derive macros.
@@ -229,7 +239,7 @@ It is possible that this inner type will be made private.
 
 You also mustn't depend on the generated `const FILLED`.
 
-More `/tests` will follow. Right now the `/examples` directory is used for some testing and as a functionality overview.
+For some more examples and an overview of functionality, take a look at `/examples` and `/tests`.
 
 ## Alternatives
 

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -238,13 +238,13 @@ fn analyze_struct(fields: &Fields) -> TokenStream {
 }
 
 fn analyze_enum(bitsize: BitSize, variants: Iter<Variant>) -> TokenStream {
+    if bitsize > MAX_ENUM_BIT_SIZE {
+        abort_call_site!("enum bitsize is limited to {}", MAX_ENUM_BIT_SIZE)
+    }
+
     let variant_count = variants.clone().count();
     if variant_count == 0 {
         abort_call_site!("empty enums are not supported");
-    }
-
-    if bitsize > MAX_ENUM_BIT_SIZE {
-        abort_call_site!("enum bitsize is limited to {}", MAX_ENUM_BIT_SIZE)
     }
     
     let has_fallback = variants.flat_map(|variant| &variant.attrs).any(is_fallback_attribute);

--- a/bilge-impl/src/bitsize_internal.rs
+++ b/bilge-impl/src/bitsize_internal.rs
@@ -71,7 +71,7 @@ fn generate_struct(struct_data: &ItemStruct, arb_int: &TokenStream) -> TokenStre
         }
         impl #ident {
             // #[inline]
-            #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+            #[allow(clippy::too_many_arguments, clippy::type_complexity, unused_parens)]
             pub #const_ fn new(#( #constructor_args )*) -> Self {
                 type ArbIntOf<T> = <T as Bitsized>::ArbitraryInt;
                 type BaseIntOf<T> = <ArbIntOf<T> as Number>::UnderlyingType;
@@ -140,7 +140,7 @@ fn generate_getter(field: &Field, offset: &TokenStream, name: &Ident) -> TokenSt
         quote! {
             // #[inline]
             #(#attrs)*
-            #[allow(clippy::type_complexity)]
+            #[allow(clippy::type_complexity, unused_parens)]
             #vis #const_ fn #name(&self, index: usize) -> #elem_ty {
                 assert!(index < #len_expr);
                 #getter_value
@@ -154,7 +154,7 @@ fn generate_getter(field: &Field, offset: &TokenStream, name: &Ident) -> TokenSt
     quote! {
         // #[inline]
         #(#attrs)*
-        #[allow(clippy::type_complexity)]
+        #[allow(clippy::type_complexity, unused_parens)]
         #vis #const_ fn #name(&self) -> #ty {
             #getter_value
         }
@@ -183,7 +183,7 @@ fn generate_setter(field: &Field, offset: &TokenStream, name: &Ident) -> TokenSt
         quote! {
             // #[inline]
             #(#attrs)*
-            #[allow(clippy::type_complexity)]
+            #[allow(clippy::type_complexity, unused_parens)]
             #vis #const_ fn #name(&mut self, index: usize, value: #elem_ty) {
                 assert!(index < #len_expr);
                 #setter_value
@@ -196,7 +196,7 @@ fn generate_setter(field: &Field, offset: &TokenStream, name: &Ident) -> TokenSt
     quote! {
         // #[inline]
         #(#attrs)*
-        #[allow(clippy::type_complexity)]
+        #[allow(clippy::type_complexity, unused_parens)]
         #vis #const_ fn #name(&mut self, value: #ty) {
             #setter_value
         }

--- a/bilge-impl/src/bitsize_internal/struct_gen.rs
+++ b/bilge-impl/src/bitsize_internal/struct_gen.rs
@@ -99,11 +99,10 @@ pub(crate) fn generate_getter_inner(ty: &Type, is_getter: bool) -> TokenStream {
                 quote! {
                     // constness: iter, array::from_fn, for-loop, range are not const, so we're using while loops
                     // Modified version of the array init example in [`MaybeUninit`]:
-                    use core::mem::MaybeUninit;
                     let array = {
                         // [T; N1*N2]
-                        let mut array: [MaybeUninit<#elem_ty>; #len_expr] = unsafe {
-                            MaybeUninit::uninit().assume_init()
+                        let mut array: [::core::mem::MaybeUninit<#elem_ty>; #len_expr] = unsafe {
+                            ::core::mem::MaybeUninit::uninit().assume_init()
                         };
                         let mut i = 0;
                         while i < #len_expr {
@@ -116,7 +115,7 @@ pub(crate) fn generate_getter_inner(ty: &Type, is_getter: bool) -> TokenStream {
                             i += 1;
                         }
                         // [T; N1*N2] -> [[T; N1]; N2]
-                        unsafe { core::mem::transmute(array) }
+                        unsafe { ::core::mem::transmute(array) }
                     };
                     array
                 }
@@ -281,7 +280,7 @@ fn generate_setter_inner(ty: &Type) -> TokenStream {
             quote! {
                 // [[T; N1]; N2] -> [T; N1*N2], for example: [[(u2, u2); 3]; 4] -> [(u2, u2); 12]
                 #[allow(clippy::useless_transmute)]
-                let value: [#elem_ty; #len_expr] = unsafe { core::mem::transmute(value) };  
+                let value: [#elem_ty; #len_expr] = unsafe { ::core::mem::transmute(value) };  
                 // constness: iter, for-loop, range are not const, so we're using while loops
                 // [u4; 8] -> u32
                 let mut acc = 0;

--- a/bilge-impl/src/debug_bits.rs
+++ b/bilge-impl/src/debug_bits.rs
@@ -13,7 +13,7 @@ pub(super) fn debug_bits(item: TokenStream) -> TokenStream {
     let struct_data = match derive_input.data {
         Data::Struct(s) => s,
         Data::Enum(_) => abort_call_site!("use derive(Debug) for enums"),
-        Data::Union(_) => abort_call_site!("item is not a struct, try derive(Debug)"),
+        Data::Union(_) => unreachable(()),
     };
     
     let fmt_impl = match struct_data.fields {

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -37,7 +37,8 @@ fn analyze_enum(variants: Iter<Variant>, name: &Ident, internal_bitsize: BitSize
         abort_call_site!("enum doesn't fill its bitsize"; help = "you need to use `#[derive(TryFromBits)]` instead, or specify one of the variants as #[fallback]")
     }
     if enum_is_filled && fallback.is_some() {
-        abort_call_site!("enum fills its bitsize but has fallback variant"; help = "remove `#[fallback]` from this enum")
+        // NOTE: I've shortly tried pointing to `#[fallback]` here but it wasn't easy enough
+        abort_call_site!("enum already has {} variants", variants.len(); help = "remove the `#[fallback]` attribute")
     }
 
     let mut assigner = DiscriminantAssigner::new(internal_bitsize);

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -125,6 +125,9 @@ pub fn is_always_filled(ty: &Type) -> bool {
 /// therefore the bitshift would not overflow.
 pub fn enum_fills_bitsize(bitsize: u8, variants_count: usize) -> bool {
     let max_variants_count = 1u128 << bitsize;
+    if variants_count as u128 > max_variants_count {
+        abort_call_site!("enum overflows its bitsize"; help = "there should only be at most {} variants defined", max_variants_count);
+    }
     variants_count as u128 == max_variants_count
 }
 

--- a/examples/nested_tuples_and_arrays.rs
+++ b/examples/nested_tuples_and_arrays.rs
@@ -3,11 +3,12 @@
 // you can use the "Expand glob import" command on
 // use bilge::prelude::*;
 // but still need to add Bitsized, Number yourself
-use bilge::prelude::{DebugBits, FromBits, TryFromBits, bitsize, u1, u4, u54, u18, u2, u39, Bitsized, Number};
+use bilge::prelude::{DebugBits, FromBits, TryFromBits, bitsize, u1, u18, u2, u39, Bitsized, Number};
 
-#[bitsize(32)]
-#[derive(DebugBits, FromBits)]
-struct TupleStruct(u8, u16, u8);
+
+// This file basically just informs you that yes, combinations of different nestings work.
+// also see `tests/struct.rs`
+
 
 #[bitsize(39)]
 #[derive(FromBits, DebugBits, PartialEq)]
@@ -35,13 +36,6 @@ enum HaveFun {
 #[bitsize(2)]
 #[derive(Clone, Copy, FromBits, DebugBits, PartialEq)]
 struct InnerTupleStruct(u1, bool);
-
-#[bitsize(54)]
-#[derive(FromBits, DebugBits, PartialEq)]
-struct Basic {
-    arr: [u4; 12],
-    tup_arr: [(u2, bool); 2],
-}
 
 fn main() {
     let field1 = (u1::new(0), (u2::new(0b00), 0b1111_1111), u1::new(1));
@@ -121,29 +115,4 @@ fn main() {
     mess.set_array_at(1, elem_0);
     assert_eq!(elem_1, mess.array_at(0));
     assert_eq!(elem_0, mess.array_at(1));
-
-    let mut basic = Basic::from(u54::new(0));
-
-    let sixth = u4::new(0b1111);
-    let eleventh = u4::new(0b1101);
-    basic.set_arr_at(6, sixth);
-    basic.set_arr_at(11, eleventh);
-
-    let z = u4::new(0);
-    assert_eq!(basic.arr(), [z, z, z, z, z, z, sixth, z, z, z, z, eleventh]);
-    assert_eq!(sixth, basic.arr_at(6));
-    assert_eq!(eleventh, basic.arr_at(11));
-
-    let z = (u2::new(0), false);
-    let zeroth = (u2::new(0b11), true);
-    basic.set_tup_arr_at(0, zeroth);
-    assert_eq!(basic.tup_arr(), [zeroth, z]);
-    assert_eq!(zeroth, basic.tup_arr_at(0));
-    assert_eq!(z, basic.tup_arr_at(1));
-
-    let first = (u2::new(0b10), false);
-    basic.set_tup_arr_at(1, first);
-    assert_eq!(basic.tup_arr(), [zeroth, first]);
-    assert_eq!(zeroth, basic.tup_arr_at(0));
-    assert_eq!(first, basic.tup_arr_at(1));
 }

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -49,6 +49,16 @@ enum Subclass {
     Reserved,
 }
 
+#[bitsize(32)]
+#[derive(FromBits, Debug, PartialEq)]
+enum Subclass2 {
+    Mouse,
+    Keyboard,
+    Speakers,
+    #[fallback]
+    Reserved(u32),
+}
+
 fn main() {
     let reg1 = Register::new(
         u4::new(0b1010),
@@ -66,10 +76,16 @@ fn main() {
     assert_eq!(0b0000_0000_0000_0000_0000_0000_0001_0100, ise.value);
 
     assert_eq!(Subclass::Reserved, Subclass::from(3));
-    let subclass = Subclass::from(42);
-    let num = u32::from(subclass);
-    assert_ne!(42, num);
+    assert_eq!(Subclass::Reserved, Subclass::from(42));
+    let num = u32::from(Subclass::from(42));
     assert_eq!(3, num);
+    assert_ne!(42, num);
+
+    assert_eq!(Subclass2::Reserved(3), Subclass2::from(3));
+    assert_eq!(Subclass2::Reserved(42), Subclass2::from(42));
+    let num = u32::from(Subclass2::from(42));
+    assert_eq!(42, num);
+    assert_ne!(3, num);
 
     let class = Class::try_from(u2::new(2));
     assert_eq!(class, Err(u2::new(2)));

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -1,0 +1,37 @@
+use bilge::prelude::*;
+
+#[bitsize(1)]
+#[derive(FromBits, PartialEq, Debug)]
+enum Date { No, Yes }
+
+#[bitsize(2)]
+#[derive(TryFromBits)]
+enum Activity { Restaurant, Skating, Movies }
+
+#[test]
+fn conversions() {
+    // `From` in both directions
+    assert_eq!(u1::new(0), u1::from(Date::No));
+    assert_eq!(u1::new(1), u1::from(Date::Yes));
+    assert_eq!(Date::No,   u1::new(0).into());
+    assert_eq!(Date::Yes,  u1::new(1).into());
+
+    // Of course converting to number is always infallible,
+    // since the discriminants need to fit the bitsize anyways.
+    // `TryFrom<uN>` and `From<Enum>`
+    for value in 0..3 {
+        let value = u2::new(value);
+        let date_activity = Activity::try_from(value);
+        match date_activity {
+            Ok(a) => {
+                match a {
+                    Activity::Restaurant => assert_eq!(u2::new(0u8), value),
+                    Activity::Skating =>    assert_eq!(u2::new(1u8), value),
+                    Activity::Movies =>     assert_eq!(u2::new(2u8), value),
+                }
+                assert_eq!(u2::from(a), value);
+            },
+            Err(e) => assert_eq!(e, u2::new(3)),
+        }
+    }
+}

--- a/tests/single_filled_enum.rs
+++ b/tests/single_filled_enum.rs
@@ -8,6 +8,7 @@ struct Wrapper {
 
 #[bitsize(32)]
 #[derive(TryFromBits, PartialEq, Debug)]
+#[repr(u32)]
 enum FillsU32 {
     Foo = 0xDEADBEEF
 }

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -393,3 +393,26 @@ fn that_one_test() {
     assert_eq!(elem_1, mess.arr_arr_ay_ay_at(0));
     assert_eq!(elem_0, mess.arr_arr_ay_ay_at(1));
 }
+
+#[bitsize(16)]
+#[derive(DebugBits)]
+struct Array([u4; 4]);
+
+#[test]
+#[should_panic(expected = "assertion failed: index < 4")]
+fn oob() {
+    let zero = u4::new(0);
+    let mut arrrr = Array::new([zero, zero, zero, zero]);
+    let one = u4::new(1);
+    arrrr.set_val_0_at(0, one);
+    arrrr.set_val_0_at(1, one);
+    assert_eq!(format!("{arrrr:?}"), "Array([1, 1, 0, 0])");
+    arrrr.set_val_0_at(2, one);
+    arrrr.set_val_0_at(3, one);
+    assert_eq!(format!("{arrrr:?}"), "Array([1, 1, 1, 1])");
+    // out of bounds
+    arrrr.set_val_0_at(4, one);
+}
+#[test]
+#[should_panic(expected = "assertion failed: index < 4")]
+fn oob2() { Array::new([u4::new(0), u4::new(0), u4::new(0), u4::new(0)]).val_0_at(4); }

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -1,0 +1,190 @@
+#![allow(clippy::unusual_byte_groupings)]
+use bilge::prelude::*;
+
+#[bitsize(1)]
+#[derive(FromBits, PartialEq, DebugBits)]
+struct Bit {
+    inner: u1,
+}
+
+#[bitsize(2)]
+#[derive(TryFromBits)]
+struct UnfilledStruct {
+    inner: Unfilled,
+}
+
+#[bitsize(2)]
+#[derive(TryFromBits, Debug)]
+enum Unfilled { A, B, C }
+
+#[test]
+fn conversions() {
+    // `From` in both directions
+    assert_eq!(u1::new(0), u1::from(Bit::new(u1::new(0))));
+    assert_eq!(u1::new(1), u1::from(Bit::new(u1::new(1))));
+    assert_eq!(Bit::new(u1::new(0)), u1::new(0).into());
+    assert_eq!(Bit::new(u1::new(1)), u1::new(1).into());
+
+    // Of course converting to number is always infallible,
+    // since the structure describes the bitpattern anyways.
+    // `TryFrom<uN>` and `From<Struct>`
+    for value in 0..3 {
+        let value = u2::new(value);
+        let date_activity = UnfilledStruct::try_from(value);
+        match date_activity {
+            Ok(a) => {
+                match a.inner() {
+                    Unfilled::A => assert_eq!(u2::new(0u8), value),
+                    Unfilled::B => assert_eq!(u2::new(1u8), value),
+                    Unfilled::C => assert_eq!(u2::new(2u8), value),
+                }
+                assert_eq!(u2::from(a), value);
+            },
+            Err(e) => assert_eq!(e, u2::new(3)),
+        }
+    }
+}
+
+#[bitsize(5)]
+#[derive(FromBits, PartialEq, DebugBits)]
+struct MultiField {
+    field1: u2,
+    field2: u1,
+    field3: u2,
+}
+
+#[test]
+fn multiple_fields() {
+    // As you can see here, the first bitfield starts at the right.
+    let a = MultiField::from(u5::new(0b11_1_01));
+    assert_eq!(a.field1(), u2::new(0b01));
+    assert_eq!(a.field2(), u1::new(0b1));
+    assert_eq!(a.field3(), u2::new(0b11));
+
+    // You can also set fields, of course.
+    let mut a = MultiField::from(u5::new(0b00_0_11));
+    a.set_field1(u2::new(0b01));
+    assert_eq!(a.field1(), u2::new(0b01));
+    assert_eq!(a.field2(), u1::new(0b0));
+    assert_eq!(a.field3(), u2::new(0b00));
+    assert_eq!(a, MultiField::from(u5::new(0b00_0_01)));
+    a.set_field2(u1::new(0b1));
+    assert_eq!(a.field1(), u2::new(0b01));
+    assert_eq!(a.field2(), u1::new(0b1));
+    assert_eq!(a.field3(), u2::new(0b00));
+    assert_eq!(a, MultiField::from(u5::new(0b00_1_01)));
+    a.set_field3(u2::new(0b11));
+    assert_eq!(a.field1(), u2::new(0b01));
+    assert_eq!(a.field2(), u1::new(0b1));
+    assert_eq!(a.field3(), u2::new(0b11));
+    assert_eq!(a, MultiField::from(u5::new(0b11_1_01)));
+
+    // Constructors set all fields, ya know?
+    let a = MultiField::new(u2::new(0b01), u1::new(0b1), u2::new(0b11));
+    assert_eq!(a.field1(), u2::new(0b01));
+    assert_eq!(a.field2(), u1::new(0b1));
+    assert_eq!(a.field3(), u2::new(0b11));
+}
+
+#[bitsize(35)]
+#[derive(FromBits, PartialEq, DebugBits)]
+struct NestedField {
+    nested: Nested,
+    field2: u1,
+    field3: u2,
+}
+
+#[bitsize(32)]
+#[derive(FromBits, PartialEq, DebugBits)]
+struct Nested {
+    field1: u2,
+    field2: u8,
+    field3: u22,
+}
+
+#[test]
+fn nested_fields() {
+    let a = NestedField::from(u35::new(0b111_1111_1111_1111_1111_0111_1111_1111_1111));
+    assert_eq!(a.nested(), Nested::from(0b___1111_1111_1111_1111_0111_1111_1111_1111));
+    assert_eq!(a.field2(), u1::new(0b1));
+    assert_eq!(a.field3(), u2::new(0b11));
+
+    let nested = a.nested();
+    assert_eq!(nested.field1(), u2::new(0b11));
+    assert_eq!(nested.field2(), 0b1111_1111);
+    assert_eq!(nested.field3(), u22::new(0b11_1111_1111_1111_1101_1111));
+
+    // Currently, setting nested fields works like this
+    let mut a = NestedField::from(u35::new(0b111_1111_1111_1111_1111_1111_1111_1111_1111));
+    let mut nested = a.nested();
+    nested.set_field2(0);
+    a.set_nested(nested);
+    assert_eq!(a.nested(), Nested::from(0b___1111_1111_1111_1111_1111_1100_0000_0011));
+
+    // Constructors don't do anything different
+    let a = NestedField::new(
+        Nested::new(u2::new(0b11), 0b1111_1111, u22::new(0b11_0000_1111_0000_1111_1111)),
+        u1::new(0b1), u2::new(0b11)
+    );
+    assert_eq!(a.nested(), Nested::from(0b___1100_0011_1100_0011_1111_1111_1111_1111));
+    assert_eq!(a.field2(), u1::new(0b1));
+    assert_eq!(a.field3(), u2::new(0b11));
+}
+
+/// _hardware hygene is important_
+#[bitsize(4)]
+#[derive(FromBits)]
+struct Bitflags {
+    dirty: bool,
+    clean: bool,
+    smelly: bool,
+    tainted: bool,
+}
+
+#[test]
+fn bools_and_bitflags_like_usage() {
+    let mut flags = Bitflags::from(u4::new(0b1101));
+    assert!(flags.dirty());
+    assert!(!flags.clean());
+    assert!(flags.smelly());
+    // spray_hardware_with_febreze();
+    //             |
+    //             v
+    flags.set_smelly(false);
+    assert!(flags.dirty());
+    assert!(!flags.clean());
+    assert!(!flags.smelly());
+}
+
+#[bitsize(64)]
+#[derive(FromBits, PartialEq, DebugBits)]
+struct MemoryMappedRegisters {
+    reserved: u14,
+    status: u2,
+    register1: u16,
+    reserved: u4,
+    register2: u12,
+    reserved: u16,
+}
+
+#[test]
+fn reserved_fields() {
+    let mapped = MemoryMappedRegisters::from(0b0000000000000000_001111110000_0000_1000000010001000_11_00000000000000);
+    let status = u2::new(0b11);
+    let register1 = u16::new(0b1000000010001000);
+    let register2 = u12::new(0b001111110000);
+    // Reserved fields are skipped in constructors and set to zero automatically
+    assert_eq!(mapped, MemoryMappedRegisters::new(status, register1, register2));
+    assert_eq!(mapped.status(), status);
+    assert_eq!(mapped.register1(), register1);
+    assert_eq!(mapped.register2(), register2);
+
+    // Reserved fields are only getter-accessible for debug purposes.
+    // This might change (i.e. no getter available, only debug-fmt info).
+    // If you think you need them to be accessible, please contact us!
+    assert_eq!(mapped.reserved_iii(), 0);
+    assert_eq!(
+        format!("{mapped:?}"),
+        "MemoryMappedRegisters { reserved_i: 0, status: 3, register1: 32904, reserved_ii: 0, register2: 1008, reserved_iii: 0 }"
+    );
+}

--- a/tests/ui/attr-value-is-invalid.rs
+++ b/tests/ui/attr-value-is-invalid.rs
@@ -5,8 +5,8 @@ use bilge::prelude::*;
 enum Test {}
 
 // one below lowest value
-// #[bitsize(0)]
-// enum Test {}
+#[bitsize(0)]
+enum Test {}
 
 // one above highest (struct) value
 #[bitsize(129)]

--- a/tests/ui/attr-value-is-invalid.rs
+++ b/tests/ui/attr-value-is-invalid.rs
@@ -1,0 +1,23 @@
+use bilge::prelude::*;
+
+// negative value
+#[bitsize(-1)]
+enum Test {}
+
+// one below lowest value
+// #[bitsize(0)]
+// enum Test {}
+
+// one above highest (struct) value
+#[bitsize(129)]
+struct Test {}
+
+// one above highest enum value
+#[bitsize(65)]
+enum Test {}
+
+// one above highest enum value, this compiles
+#[bitsize(65)]
+struct Test { field: u65 }
+
+fn main() {}

--- a/tests/ui/attr-value-is-invalid.stderr
+++ b/tests/ui/attr-value-is-invalid.stderr
@@ -6,14 +6,13 @@ error: attribute value is not a valid number
   |
   = help: currently, numbers from 1 to 128 are allowed
 
-error: attribute is not a valid number
-  --> tests/ui/attr-value-is-invalid.rs:12:1
+error: attribute value is not a valid number
+  --> tests/ui/attr-value-is-invalid.rs:12:11
    |
 12 | #[bitsize(129)]
-   | ^^^^^^^^^^^^^^^
+   |           ^^^
    |
    = help: currently, numbers from 1 to 128 are allowed
-   = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: enum bitsize is limited to 64
   --> tests/ui/attr-value-is-invalid.rs:16:1

--- a/tests/ui/attr-value-is-invalid.stderr
+++ b/tests/ui/attr-value-is-invalid.stderr
@@ -1,0 +1,24 @@
+error: attribute value is not a valid number
+ --> tests/ui/attr-value-is-invalid.rs:4:11
+  |
+4 | #[bitsize(-1)]
+  |           ^^
+  |
+  = help: currently, numbers from 1 to 128 are allowed
+
+error: attribute is not a valid number
+  --> tests/ui/attr-value-is-invalid.rs:12:1
+   |
+12 | #[bitsize(129)]
+   | ^^^^^^^^^^^^^^^
+   |
+   = help: currently, numbers from 1 to 128 are allowed
+   = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: enum bitsize is limited to 64
+  --> tests/ui/attr-value-is-invalid.rs:17:1
+   |
+17 | #[bitsize(65)]
+   | ^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/attr-value-is-invalid.stderr
+++ b/tests/ui/attr-value-is-invalid.stderr
@@ -7,6 +7,14 @@ error: attribute value is not a valid number
   = help: currently, numbers from 1 to 128 are allowed
 
 error: attribute value is not a valid number
+ --> tests/ui/attr-value-is-invalid.rs:8:11
+  |
+8 | #[bitsize(0)]
+  |           ^
+  |
+  = help: currently, numbers from 1 to 128 are allowed
+
+error: attribute value is not a valid number
   --> tests/ui/attr-value-is-invalid.rs:12:11
    |
 12 | #[bitsize(129)]

--- a/tests/ui/attr-value-is-invalid.stderr
+++ b/tests/ui/attr-value-is-invalid.stderr
@@ -16,9 +16,9 @@ error: attribute is not a valid number
    = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: enum bitsize is limited to 64
-  --> tests/ui/attr-value-is-invalid.rs:17:1
+  --> tests/ui/attr-value-is-invalid.rs:16:1
    |
-17 | #[bitsize(65)]
+16 | #[bitsize(65)]
    | ^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/attr-value-is-not-a-number.rs
+++ b/tests/ui/attr-value-is-not-a-number.rs
@@ -3,4 +3,7 @@ use bilge::bitsize;
 #[bitsize(...)]
 enum Test {}
 
+#[bitsize("12")]
+enum Test2 {}
+
 fn main() {}

--- a/tests/ui/attr-value-is-not-a-number.stderr
+++ b/tests/ui/attr-value-is-not-a-number.stderr
@@ -5,3 +5,11 @@ error: attribute value is not a number
   |           ^^^
   |
   = help: you need to define the size like this: `#[bitsize(32)]`
+
+error: attribute value is not a number
+ --> tests/ui/attr-value-is-not-a-number.rs:6:11
+  |
+6 | #[bitsize("12")]
+  |           ^^^^
+  |
+  = help: you need to define the size like this: `#[bitsize(32)]`

--- a/tests/ui/debug-bits-should-be-used.rs
+++ b/tests/ui/debug-bits-should-be-used.rs
@@ -1,0 +1,26 @@
+use bilge::prelude::*;
+
+// structs should use `DebugBits`
+#[bitsize(4)]
+#[derive(Debug)]
+struct A(u4);
+
+// might as well test deeper paths
+#[bitsize(4)]
+#[derive(fmt::Debug)]
+struct A(u4);
+
+#[bitsize(4)]
+#[derive(core::fmt::Debug)]
+struct A(u4);
+
+#[bitsize(4)]
+#[derive(std::fmt::Debug)]
+struct A(u4);
+
+// enums should use `Debug`
+#[bitsize(1)]
+#[derive(DebugBits)]
+enum B { A, B }
+
+fn main() {}

--- a/tests/ui/debug-bits-should-be-used.stderr
+++ b/tests/ui/debug-bits-should-be-used.stderr
@@ -1,0 +1,31 @@
+error: use derive(DebugBits) for structs
+ --> tests/ui/debug-bits-should-be-used.rs:5:10
+  |
+5 | #[derive(Debug)]
+  |          ^^^^^
+
+error: use derive(DebugBits) for structs
+  --> tests/ui/debug-bits-should-be-used.rs:10:10
+   |
+10 | #[derive(fmt::Debug)]
+   |          ^^^^^^^^^^
+
+error: use derive(DebugBits) for structs
+  --> tests/ui/debug-bits-should-be-used.rs:14:10
+   |
+14 | #[derive(core::fmt::Debug)]
+   |          ^^^^^^^^^^^^^^^^
+
+error: use derive(DebugBits) for structs
+  --> tests/ui/debug-bits-should-be-used.rs:18:10
+   |
+18 | #[derive(std::fmt::Debug)]
+   |          ^^^^^^^^^^^^^^^
+
+error: use derive(Debug) for enums
+  --> tests/ui/debug-bits-should-be-used.rs:23:10
+   |
+23 | #[derive(DebugBits)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `DebugBits` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/derive-above-bitsize.rs
+++ b/tests/ui/derive-above-bitsize.rs
@@ -1,0 +1,7 @@
+use bilge::prelude::*;
+
+#[derive(FromBits)]
+#[bitsize(4)]
+struct A(u4);
+
+fn main() {}

--- a/tests/ui/derive-above-bitsize.stderr
+++ b/tests/ui/derive-above-bitsize.stderr
@@ -1,0 +1,7 @@
+error: add #[bitsize] attribute above your derive attribute
+ --> tests/ui/derive-above-bitsize.rs:3:10
+  |
+3 | #[derive(FromBits)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/discriminant-invalid.rs
+++ b/tests/ui/discriminant-invalid.rs
@@ -1,0 +1,20 @@
+use bilge::prelude::*;
+
+
+const EXTERNAL: isize = 1;
+
+#[bitsize(1)]
+#[derive(FromBits)]
+enum B {
+    A = EXTERNAL,
+    B,
+}
+
+#[bitsize(1)]
+#[derive(FromBits)]
+enum C {
+    NineNine = 1,
+    PlusPlus = 2,
+}
+
+fn main() {}

--- a/tests/ui/discriminant-invalid.rs
+++ b/tests/ui/discriminant-invalid.rs
@@ -17,4 +17,22 @@ enum C {
     PlusPlus = 2,
 }
 
+// I just put this here since I noticed it here
+#[bitsize(1)]
+#[derive(FromBits)]
+enum D {
+    NineNine = 0,
+    Sharp = 1,
+    #[fallback]
+    PlusPlus,
+}
+
+#[bitsize(1)]
+#[derive(FromBits)]
+enum E {
+    NineNine = 0,
+    Sharp = 1,
+    PlusPlus = 2,
+}
+
 fn main() {}

--- a/tests/ui/discriminant-invalid.stderr
+++ b/tests/ui/discriminant-invalid.stderr
@@ -1,0 +1,13 @@
+error: variant `A` is not a number
+ --> tests/ui/discriminant-invalid.rs:9:9
+  |
+9 |     A = EXTERNAL,
+  |         ^^^^^^^^
+  |
+  = help: only literal integers currently supported
+
+error: Value of variant exceeds the given number of bits
+  --> tests/ui/discriminant-invalid.rs:17:5
+   |
+17 |     PlusPlus = 2,
+   |     ^^^^^^^^^^^^

--- a/tests/ui/discriminant-invalid.stderr
+++ b/tests/ui/discriminant-invalid.stderr
@@ -11,3 +11,21 @@ error: Value of variant exceeds the given number of bits
    |
 17 |     PlusPlus = 2,
    |     ^^^^^^^^^^^^
+
+error: enum overflows its bitsize
+  --> tests/ui/discriminant-invalid.rs:22:10
+   |
+22 | #[derive(FromBits)]
+   |          ^^^^^^^^
+   |
+   = help: there should only be at most 2 variants defined
+   = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: enum overflows its bitsize
+  --> tests/ui/discriminant-invalid.rs:30:1
+   |
+30 | #[bitsize(1)]
+   | ^^^^^^^^^^^^^
+   |
+   = help: there should only be at most 2 variants defined
+   = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/empty-items-are-not-supported.rs
+++ b/tests/ui/empty-items-are-not-supported.rs
@@ -1,0 +1,13 @@
+use bilge::prelude::*;
+
+#[bitsize(1)]
+struct A;
+#[bitsize(1)]
+struct A();
+#[bitsize(1)]
+struct A{}
+
+#[bitsize(1)]
+enum B {}
+
+fn main() {}

--- a/tests/ui/empty-items-are-not-supported.stderr
+++ b/tests/ui/empty-items-are-not-supported.stderr
@@ -1,0 +1,31 @@
+error: structs without fields are not supported
+ --> tests/ui/empty-items-are-not-supported.rs:3:1
+  |
+3 | #[bitsize(1)]
+  | ^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: structs without fields are not supported
+ --> tests/ui/empty-items-are-not-supported.rs:5:1
+  |
+5 | #[bitsize(1)]
+  | ^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: structs without fields are not supported
+ --> tests/ui/empty-items-are-not-supported.rs:7:1
+  |
+7 | #[bitsize(1)]
+  | ^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: empty enums are not supported
+  --> tests/ui/empty-items-are-not-supported.rs:10:1
+   |
+10 | #[bitsize(1)]
+   | ^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/fallback/more.rs
+++ b/tests/ui/fallback/more.rs
@@ -1,0 +1,45 @@
+use bilge::prelude::*;
+
+#[bitsize(15)]
+#[derive(FromBits)]
+enum Testing {
+    A,
+    D,
+    H,
+    #[fallback]
+    Dee { fallback: u15 },
+}
+
+#[bitsize(15)]
+#[derive(FromBits)]
+enum Windows {
+    I,
+    N,
+    #[fallback]
+    Tel(u8, u7),
+}
+
+#[bitsize(15)]
+#[derive(FromBits)]
+enum Alt {
+    F,
+    #[fallback]
+    Four(Option<u8>),
+}
+
+#[bitsize(15)]
+#[derive(FromBits)]
+enum James {
+    Atomic,
+    #[fallback]
+    Habits(u100),
+}
+
+#[bitsize(15)]
+#[derive(FromBits)]
+struct Dum {
+    #[fallback]
+    my: u15,
+}
+
+fn main() {}

--- a/tests/ui/fallback/more.stderr
+++ b/tests/ui/fallback/more.stderr
@@ -1,0 +1,38 @@
+error: `#[fallback]` does not support variants with named fields
+  --> tests/ui/fallback/more.rs:9:5
+   |
+9  | /     #[fallback]
+10 | |     Dee { fallback: u15 },
+   | |_________________________^
+   |
+   = help: use a tuple variant or remove this `#[fallback]`
+
+error: fallback variant must have exactly one field
+  --> tests/ui/fallback/more.rs:18:5
+   |
+18 | /     #[fallback]
+19 | |     Tel(u8, u7),
+   | |_______________^
+   |
+   = help: use only one field or change to a unit variant
+
+error: `#[fallback]` only supports arbitrary_int or bool types
+  --> tests/ui/fallback/more.rs:27:9
+   |
+27 |     Four(Option<u8>),
+   |         ^^^^^^^^^^^^
+
+error: bitsize of fallback field (100) does not match bitsize of enum (15)
+  --> tests/ui/fallback/more.rs:35:11
+   |
+35 |     Habits(u100),
+   |           ^^^^^^
+
+error: `#[fallback]` is only applicable to enums
+  --> tests/ui/fallback/more.rs:39:10
+   |
+39 | #[derive(FromBits)]
+   |          ^^^^^^^^
+   |
+   = help: remove all `#[fallback]` from this struct
+   = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/field-type-is-not-supported.rs
+++ b/tests/ui/field-type-is-not-supported.rs
@@ -1,0 +1,46 @@
+use bilge::prelude::*;
+
+// NOTE: this only spits out the first field error,
+// but I checked the others + it doesn't matter too much
+#[bitsize(4)]
+struct A {
+    // BareFn(_)
+    a: fn(),
+
+    // Group(_)
+    // b: ???,
+
+    // ImplTrait(_)
+    c: impl Debug,
+
+    // Infer(_)
+    d: _,
+
+    // Macro(_)
+    e: field!(),
+
+    // Never(_)
+    f: !,
+
+    // Ptr(_)
+    g: *const u8,
+    h: *mut u8,
+
+    // Reference(_)
+    i: &u8,
+    j: &mut u8,
+
+    // Slice(_)
+    k: &[u8],
+
+    // TraitObject(_)
+    l: dyn Debug,
+
+    // Verbatim(_)
+    // ---
+
+    // Paren(_)
+    m: (u8),
+}
+
+fn main() {}

--- a/tests/ui/field-type-is-not-supported.stderr
+++ b/tests/ui/field-type-is-not-supported.stderr
@@ -1,0 +1,5 @@
+error: This field type is not supported
+ --> tests/ui/field-type-is-not-supported.rs:8:8
+  |
+8 |     a: fn(),
+  |        ^^^^

--- a/tests/ui/from-tryfrom-bits-is-invalid.rs
+++ b/tests/ui/from-tryfrom-bits-is-invalid.rs
@@ -1,0 +1,36 @@
+use bilge::prelude::*;
+
+#[bitsize(4)]
+#[derive(FromBits)]
+enum A {
+    B, C
+}
+
+#[bitsize(2)]
+#[derive(FromBits)]
+enum F {
+    B,
+    C,
+    D,
+    #[fallback]
+    E
+}
+
+#[bitsize(2)]
+#[derive(TryFromBits)]
+enum X {
+    M,
+    A,
+    S(u6),
+}
+
+#[bitsize(2)]
+#[derive(TryFromBits)]
+enum L {
+    I,
+    K,
+    #[fallback]
+    E(u2),
+}
+
+fn main() {}

--- a/tests/ui/from-tryfrom-bits-is-invalid.stderr
+++ b/tests/ui/from-tryfrom-bits-is-invalid.stderr
@@ -1,0 +1,34 @@
+error: enum doesn't fill its bitsize
+ --> tests/ui/from-tryfrom-bits-is-invalid.rs:4:10
+  |
+4 | #[derive(FromBits)]
+  |          ^^^^^^^^
+  |
+  = help: you need to use `#[derive(TryFromBits)]` instead, or specify one of the variants as #[fallback]
+  = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: enum fills its bitsize but has fallback variant
+  --> tests/ui/from-tryfrom-bits-is-invalid.rs:10:10
+   |
+10 | #[derive(FromBits)]
+   |          ^^^^^^^^
+   |
+   = help: remove `#[fallback]` from this enum
+   = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: TryFromBits only supports unit variants in enums
+  --> tests/ui/from-tryfrom-bits-is-invalid.rs:24:5
+   |
+24 |     S(u6),
+   |     ^^^^^
+   |
+   = help: change this variant to a unit
+
+error: fallback is not allowed with `TryFromBits`
+  --> tests/ui/from-tryfrom-bits-is-invalid.rs:28:10
+   |
+28 | #[derive(TryFromBits)]
+   |          ^^^^^^^^^^^
+   |
+   = help: use `#[derive(FromBits)]` or remove this `#[fallback]`
+   = note: this error originates in the derive macro `TryFromBits` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/from-tryfrom-bits-is-invalid.stderr
+++ b/tests/ui/from-tryfrom-bits-is-invalid.stderr
@@ -7,13 +7,13 @@ error: enum doesn't fill its bitsize
   = help: you need to use `#[derive(TryFromBits)]` instead, or specify one of the variants as #[fallback]
   = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: enum fills its bitsize but has fallback variant
+error: enum already has 4 variants
   --> tests/ui/from-tryfrom-bits-is-invalid.rs:10:10
    |
 10 | #[derive(FromBits)]
    |          ^^^^^^^^
    |
-   = help: remove `#[fallback]` from this enum
+   = help: remove the `#[fallback]` attribute
    = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: TryFromBits only supports unit variants in enums

--- a/tests/ui/internal-attr-is-forbidden.rs
+++ b/tests/ui/internal-attr-is-forbidden.rs
@@ -1,0 +1,11 @@
+use bilge::prelude::*;
+
+// TODO?: validating `bitsize_internal` is not used alone, like:
+// #[bitsize_internal] struct A;
+// would be possible by generating a marker trait or sth in `bitsize`
+
+#[bitsize(4)]
+#[bitsize_internal]
+struct A;
+
+fn main() {}

--- a/tests/ui/internal-attr-is-forbidden.stderr
+++ b/tests/ui/internal-attr-is-forbidden.stderr
@@ -1,0 +1,7 @@
+error: remove bitsize_internal
+ --> tests/ui/internal-attr-is-forbidden.rs:8:1
+  |
+8 | #[bitsize_internal]
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = help: attribute bitsize_internal can only be applied internally by the bitsize macros

--- a/tests/ui/item-type-is-not-supported.rs
+++ b/tests/ui/item-type-is-not-supported.rs
@@ -1,0 +1,9 @@
+use bilge::bitsize;
+
+#[bitsize(8)]
+union Test {
+    a: u8,
+    b: (u4, u4),
+}
+
+fn main() {}

--- a/tests/ui/item-type-is-not-supported.stderr
+++ b/tests/ui/item-type-is-not-supported.stderr
@@ -1,0 +1,8 @@
+error: item is not a struct or enum
+ --> tests/ui/item-type-is-not-supported.rs:3:1
+  |
+3 | #[bitsize(8)]
+  | ^^^^^^^^^^^^^
+  |
+  = help: `#[bitsize]` can only be used on structs and enums
+  = note: this error originates in the attribute macro `bitsize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/non-exhaustive-invalid.rs
+++ b/tests/ui/non-exhaustive-invalid.rs
@@ -1,0 +1,23 @@
+use bilge::prelude::*;
+
+#[bitsize(4)]
+#[derive(FromBits)]
+#[non_exhaustive]
+struct A(u4);
+
+#[bitsize(4)]
+#[derive(FromBits)]
+#[non_exhaustive]
+enum B { A, B, C }
+
+#[bitsize(4)]
+#[derive(TryFromBits)]
+#[non_exhaustive]
+struct C(u4);
+
+#[bitsize(4)]
+#[derive(TryFromBits)]
+#[non_exhaustive]
+enum D { A, B, C }
+
+fn main() {}

--- a/tests/ui/non-exhaustive-invalid.stderr
+++ b/tests/ui/non-exhaustive-invalid.stderr
@@ -1,0 +1,26 @@
+error: Item can't be FromBits and non_exhaustive
+ --> tests/ui/non-exhaustive-invalid.rs:4:10
+  |
+4 | #[derive(FromBits)]
+  |          ^^^^^^^^
+  |
+  = help: remove #[non_exhaustive] or derive(FromBits) here
+  = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Item can't be FromBits and non_exhaustive
+ --> tests/ui/non-exhaustive-invalid.rs:9:10
+  |
+9 | #[derive(FromBits)]
+  |          ^^^^^^^^
+  |
+  = help: remove #[non_exhaustive] or derive(FromBits) here
+  = note: this error originates in the derive macro `FromBits` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Using #[non_exhaustive] on structs is currently not supported
+  --> tests/ui/non-exhaustive-invalid.rs:14:10
+   |
+14 | #[derive(TryFromBits)]
+   |          ^^^^^^^^^^^
+   |
+   = help: open an issue on our repository if needed
+   = note: this error originates in the derive macro `TryFromBits` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/special-cased/zerocopy-is-not-frombits.rs
+++ b/tests/ui/special-cased/zerocopy-is-not-frombits.rs
@@ -1,0 +1,7 @@
+use bilge::prelude::*;
+
+#[bitsize(32)]
+#[derive(zerocopy::FromBytes)]
+struct Group([bool; 32]);
+
+fn main() {}

--- a/tests/ui/special-cased/zerocopy-is-not-frombits.stderr
+++ b/tests/ui/special-cased/zerocopy-is-not-frombits.stderr
@@ -1,0 +1,5 @@
+error: a bitfield struct with zerocopy::FromBytes also needs to have FromBits
+ --> tests/ui/special-cased/zerocopy-is-not-frombits.rs:4:10
+  |
+4 | #[derive(zerocopy::FromBytes)]
+  |          ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/vis-privacy-is-respected.rs
+++ b/tests/ui/vis-privacy-is-respected.rs
@@ -1,0 +1,48 @@
+use bilge::prelude::*;
+
+mod hidden {
+    use super::*;
+    #[bitsize(96)]
+    #[derive(FromBits)]
+    pub struct Diary(u48, pub u48);
+
+    #[bitsize(8)]
+    #[derive(FromBits)]
+    pub struct ArrayAt(pub [u2; 2], [u2; 2]);
+
+    #[bitsize(128)]
+    #[derive(FromBits)]
+    pub struct Reserver {
+        pub reserved: u8,
+        pub(crate) padding: u8,
+        reserved: u16,
+        // the best use for padding
+        pub padding: Diary,
+    }
+}
+use hidden::*;
+
+fn main() {
+    let ascii = u48::new(0b01001001_00100000_01101100_01101111_01110110_01100101);
+    let rusti = u48::new(0b00100000_01110010_01110101_01110011_01110100_00101110);
+    let mut diary = Diary::new(ascii, rusti);
+    diary.val_0();
+    diary.val_1();
+    diary.set_val_0(rusti);
+    diary.set_val_1(ascii);
+
+    let mut a = ArrayAt::from(42);
+    a.val_0_at(1);
+    a.set_val_0_at(1, u2::new(0));
+    a.val_1_at(1);
+    a.set_val_1_at(1, u2::new(0));
+
+    // NOTE: as noted in another test case, `reserved` fields should mean "never used" and
+    // might soon only be available to `DebugBits`, unless you need it. Then please open a github issue.
+    // Right now though they have getters and do respect visibility:
+    let mut r = Reserver::from(42);
+    r.reserved_i();
+    r.padding_i();
+    r.reserved_ii();
+    r.padding_ii();
+}

--- a/tests/ui/vis-privacy-is-respected.stderr
+++ b/tests/ui/vis-privacy-is-respected.stderr
@@ -1,0 +1,44 @@
+error[E0624]: associated function `val_0` is private
+  --> tests/ui/vis-privacy-is-respected.rs:29:11
+   |
+5  |     #[bitsize(96)]
+   |     -------------- private associated function defined here
+...
+29 |     diary.val_0();
+   |           ^^^^^ private associated function
+
+error[E0624]: associated function `set_val_0` is private
+  --> tests/ui/vis-privacy-is-respected.rs:31:11
+   |
+5  |     #[bitsize(96)]
+   |     -------------- private associated function defined here
+...
+31 |     diary.set_val_0(rusti);
+   |           ^^^^^^^^^ private associated function
+
+error[E0624]: associated function `val_1_at` is private
+  --> tests/ui/vis-privacy-is-respected.rs:37:7
+   |
+9  |     #[bitsize(8)]
+   |     ------------- private associated function defined here
+...
+37 |     a.val_1_at(1);
+   |       ^^^^^^^^ private associated function
+
+error[E0624]: associated function `set_val_1_at` is private
+  --> tests/ui/vis-privacy-is-respected.rs:38:7
+   |
+9  |     #[bitsize(8)]
+   |     ------------- private associated function defined here
+...
+38 |     a.set_val_1_at(1, u2::new(0));
+   |       ^^^^^^^^^^^^ private associated function
+
+error[E0624]: associated function `reserved_ii` is private
+  --> tests/ui/vis-privacy-is-respected.rs:46:7
+   |
+13 |     #[bitsize(128)]
+   |     --------------- private associated function defined here
+...
+46 |     r.reserved_ii();
+   |       ^^^^^^^^^^^ private associated function


### PR DESCRIPTION
Closes #20.
@pickx take a look, did I miss some basic thing we should include?

- [x] I'll move over the nested examples later and also add `array_at` testing.
- [x] Still have to update the README.
- [x] Also reminds me that I should update the `fallback` stuff in the README.
- [x] Also-Also some quick fixes found while testing