### PR TITLE
Change error type

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ meaning this will work:
 
 ```rust
 let class = Class::try_from(u2::new(2));
-assert_eq!(class, Err(u2::new(2)));
+assert!(class.is_err());
 ```
 
 except we first need to `#[derive(Debug, PartialEq)]` on `Class`, since `assert_eq!` needs those.

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -64,12 +64,12 @@ fn codegen_enum(arb_int: TokenStream, enum_type: &Ident, match_arms: (Vec<TokenS
     let from_enum_impl = shared::generate_from_enum_impl(&arb_int, enum_type, to_int_match_arms, &const_);
     quote! {
         impl #const_ ::core::convert::TryFrom<#arb_int> for #enum_type {
-            type Error = #arb_int;
+            type Error = ::bilge::BitsError;
 
             fn try_from(number: #arb_int) -> ::core::result::Result<Self, Self::Error> {
                 match number.value() {
                     #( #from_int_match_arms )*
-                    i => Err(#arb_int::new(i)),
+                    i => Err(::bilge::give_me_error()),
                 }
             }
         }
@@ -112,7 +112,7 @@ fn codegen_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields) ->
 
     quote! {
         impl #const_ ::core::convert::TryFrom<#arb_int> for #struct_type {
-            type Error = #arb_int;
+            type Error = ::bilge::BitsError;
             
             // validates all values, which means enums, even in inner structs (TODO: and reserved fields?)
             fn try_from(value: #arb_int) -> ::core::result::Result<Self, Self::Error> {
@@ -127,7 +127,7 @@ fn codegen_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields) ->
                 if is_ok {
                     Ok(Self { value })
                 } else {
-                    Err(value)
+                    Err(::bilge::give_me_error())
                 }
             }
         }

--- a/examples/nested_tuples_and_arrays.rs
+++ b/examples/nested_tuples_and_arrays.rs
@@ -105,7 +105,7 @@ fn main() {
     assert_eq!(uem1.value, uem2.value);
     assert_eq!(uem1, uem2);
     let err = UnfilledEnumMess::try_from(u18::new(0b1_0101_11___11____0_1010_1010));
-    assert_eq!(err, Err(u18::new(0b1_0101_11___11____0_1010_1010)));
+    assert!(err.is_err());
 
     // mess.array_at(2); //panics, like it should
 

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -88,7 +88,7 @@ fn main() {
     assert_ne!(3, num);
 
     let class = Class::try_from(u2::new(2));
-    assert_eq!(class, Err(u2::new(2)));
+    assert!(class.is_err());
     println!("{:?}", Device::try_from(0b0000_11_00));
     println!("{:?}", Device::new(Class::Mobile));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,18 @@ unsafe impl<T> Filled for T where T: Bitsized + From<<T as Bitsized>::ArbitraryI
 /// This is generated to statically validate that a type implements `FromBits`.
 pub fn assume_filled<T: Filled>() {}
 
+#[non_exhaustive]
+#[derive(Debug, PartialEq)]
+pub struct BitsError;
+
+/// Internally used for generating the `Result::Err` type in `TryFrom`.
+/// 
+/// This is needed since we don't want users to be able to create `BitsError` right now.
+/// We'll be able to turn `BitsError` into an enum later, or anything else really.
+pub fn give_me_error() -> BitsError {
+    BitsError
+}
+
 /// Only basing this on Number did not work, as bool and others are not Number.
 /// We could remove the whole macro_rules thing if it worked, though.
 /// Maybe there is some way to do this, I'm not deep into types.

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -19,7 +19,7 @@ fn conversions() {
     // Of course converting to number is always infallible,
     // since the discriminants need to fit the bitsize anyways.
     // `TryFrom<uN>` and `From<Enum>`
-    for value in 0..3 {
+    for value in 0..4{
         let value = u2::new(value);
         let date_activity = Activity::try_from(value);
         match date_activity {
@@ -31,7 +31,7 @@ fn conversions() {
                 }
                 assert_eq!(u2::from(a), value);
             },
-            Err(e) => assert_eq!(e, u2::new(3)),
+            Err(e) => assert_eq!(format!("{e:?}"), "BitsError"),
         }
     }
 }

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -28,7 +28,7 @@ fn conversions() {
     // Of course converting to number is always infallible,
     // since the structure describes the bitpattern anyways.
     // `TryFrom<uN>` and `From<Struct>`
-    for value in 0..3 {
+    for value in 0..4 {
         let value = u2::new(value);
         let date_activity = UnfilledStruct::try_from(value);
         match date_activity {
@@ -40,7 +40,7 @@ fn conversions() {
                 }
                 assert_eq!(u2::from(a), value);
             },
-            Err(e) => assert_eq!(e, u2::new(3)),
+            Err(e) => assert_eq!(format!("{e:?}"), "BitsError"),
         }
     }
 }
@@ -381,8 +381,7 @@ fn that_one_test() {
     assert_eq!(uem1, uem2);
     let raw = u18::new(0b1_0101_11___11____0_1010_1010);
     let err = UnfilledEnumMess::try_from(raw);
-    // TODO: `TryFrom` will soon not return `Err(uN)` anymore
-    assert_eq!(err, Err(raw));
+    assert!(err.is_err());
 
     // mess.arr_arr_ay_ay_at(2); //panics, like it should
 

--- a/tests/ui/err-type-is-not-usable.rs
+++ b/tests/ui/err-type-is-not-usable.rs
@@ -1,0 +1,19 @@
+use bilge::prelude::*;
+
+#[bitsize(2)]
+#[derive(TryFromBits)]
+enum Dna {
+    C,
+    G,
+    A,
+}
+
+fn main() {
+    let res = Dna::try_from(u2::new(3));
+    match res {
+        Ok(Dna::C) => println!("cytosine"),
+        Ok(Dna::G) => println!("guanine"),
+        Ok(Dna::A) => println!("adenine"),
+        Err(bilge::BitsError) => println!("thymine"),
+    }
+}

--- a/tests/ui/err-type-is-not-usable.stderr
+++ b/tests/ui/err-type-is-not-usable.stderr
@@ -1,0 +1,11 @@
+error[E0603]: unit struct `BitsError` is private
+  --> tests/ui/err-type-is-not-usable.rs:17:20
+   |
+17 |         Err(bilge::BitsError) => println!("thymine"),
+   |                    ^^^^^^^^^ private unit struct
+   |
+note: the unit struct `BitsError` is defined here
+  --> src/lib.rs
+   |
+   | pub struct BitsError;
+   | ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes #49.

BREAKING CHANGE: Previously we just returned the value which was passed into try_from, which is useless.
For now we change this to a useless unit struct, which enables a better error type in the future.

This means we'll publish a `0.2.0`, to make it sound a bit more breaky, and we added a ton of changes anyways.