### PR TITLE
refactor attribute splitting logic

### DIFF
--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -5,7 +5,7 @@ use proc_macro_error::{abort_call_site, abort};
 use quote::quote;
 use syn::{punctuated::Iter, Variant, Item, ItemStruct, ItemEnum, Type, Fields, spanned::Spanned};
 use crate::shared::{self, BitSize, unreachable, enum_fills_bitsize, is_fallback_attribute, MAX_ENUM_BIT_SIZE};
-use split::{split_item_attributes, SplitAttributes};
+use split::SplitAttributes;
 
 /// Intermediate Representation, just for bundling these together
 struct ItemIr {
@@ -15,7 +15,7 @@ struct ItemIr {
 
 pub(super) fn bitsize(args: TokenStream, item: TokenStream) -> TokenStream {
     let (item, declared_bitsize) = parse(item, args);
-    let attrs = split_item_attributes(&item);
+    let attrs = SplitAttributes::from_item(&item);
     let ir = match item {
         Item::Struct(mut item) => {
             modify_special_field_names(&mut item.fields);

--- a/bilge-impl/src/bitsize/split.rs
+++ b/bilge-impl/src/bitsize/split.rs
@@ -1,0 +1,185 @@
+use proc_macro_error::{abort_call_site, abort};
+use quote::ToTokens;
+use syn::{meta::ParseNestedMeta, Path, Item, Attribute, Meta, parse_quote};
+use crate::shared::unreachable;
+
+/// Since we want to be maximally interoperable, we need to handle attributes in a special way.
+/// We use `#[bitsize]` as a sort of scope for all attributes below it and
+/// the whole family of `-Bits` macros only works when used in that scope.
+/// 
+/// Let's visualize why this is the case, starting with some user-code:
+/// ```ignore
+/// #[bitsize(6)]
+/// #[derive(Clone, Copy, PartialEq, DebugBits, FromBits)]
+/// struct Example {
+///     field1: u2,
+///     field2: u4,
+/// }
+/// ```
+/// First, the attributes get sorted, depending on their name.
+/// Every attribute in need of field information gets resolved first,
+/// in this case `DebugBits` and `FromBits`.
+/// 
+/// Now, after resolving all `before_compression` attributes, the halfway-resolved
+/// code looks like this:
+/// ```ignore
+/// #[bilge::bitsize_internal(6)]
+/// #[derive(Clone, Copy, PartialEq)]
+/// struct Example {
+///     field1: u2,
+///     field2: u4,
+/// }
+/// ```
+/// This `#[bitsize_internal]` attribute is the one actually doing the compression and generating
+/// all the getters, setters and a constructor.
+/// 
+/// Finally, the struct ends up like this (excluding the generated impl blocks):
+/// ```ignore
+/// struct Example {
+///     value: u6,
+/// }
+/// ```
+pub struct SplitAttributes {
+    pub before_compression: Vec<Attribute>,
+    pub after_compression: Vec<Attribute>,
+}
+
+/// Split item attributes into those applied before bitfield-compression and those applied after.
+/// Also, abort on any invalid configuration.
+/// 
+/// Any derives with suffix `Bits` will be able to access field information.
+/// This way, users of `bilge` can define their own derives working on the uncompressed bitfield.
+pub fn split_item_attributes(item: &Item) -> SplitAttributes {
+    let attrs = match item {
+        Item::Enum(item) => &item.attrs,
+        Item::Struct(item) => &item.attrs,
+        _ => abort_call_site!("item is not a struct or enum"; help = "`#[bitsize]` can only be used on structs and enums"),
+    };
+
+    let parsed = attrs.iter().map(parse_attribute);
+    
+    let is_struct = matches!(item, Item::Struct(..));
+    
+    let mut from_bytes = None;
+    let mut has_frombits = false;
+
+    let mut before_compression = vec![];
+    let mut after_compression = vec![];
+
+    for parsed_attr in parsed {
+        match parsed_attr {
+            ParsedAttribute::DeriveList(derives) => {
+                for derive in derives {
+                    // NOTE: we could also handle `::{path}`
+                    match derive.to_string().as_str() {
+                        "FromBytes" | "zerocopy :: FromBytes" => from_bytes = Some(derive.clone()),
+                        "FromBits" | "bilge :: FromBits" => has_frombits = true,
+                        "Debug" | "fmt :: Debug" | "core :: fmt :: Debug" | "std :: fmt :: Debug" if is_struct => {
+                            abort!(derive.0, "use derive(DebugBits) for structs")
+                        }
+                        _ => {}
+                    };
+
+                
+                    if derive.is_bitfield_derive() {
+                        // this handles the custom derives
+                        before_compression.push(derive.into_attribute());
+                    } else {
+                        // It is most probable that basic derive macros work if we put them on after compression
+                        after_compression.push(derive.into_attribute());
+                    }
+                }
+            },
+
+            ParsedAttribute::BitsizeInternal(attr) => {
+                abort!(attr, "remove bitsize_internal"; help = "attribute bitsize_internal can only be applied internally by the bitsize macros")
+            },
+
+            ParsedAttribute::Other(attr) => {
+                // I don't know with which attrs I can hit Path and NameValue,
+                // so let's just put them on after compression.
+                after_compression.push(attr.clone())
+            },
+        };
+    }
+
+    if let Some(from_bytes) = from_bytes {
+        // TODO: is this error also applicable to enums?
+        if !has_frombits && is_struct {
+            abort!(from_bytes.0, "a bitfield struct with zerocopy::FromBytes also needs to have FromBits")
+        }
+    }
+
+    // currently, enums don't need special handling - so just put all attributes before compression
+    //
+    // TODO: this doesn't preserve order, in the sense that an "after compression" attribute will appear
+    // after all "before compression" attributes. is that okay?
+    if !is_struct {
+        before_compression.append(&mut after_compression)
+    }
+    
+    SplitAttributes { before_compression, after_compression }    
+}
+
+fn parse_attribute(attribute: &Attribute) -> ParsedAttribute {
+    match &attribute.meta {
+        Meta::List(list) if list.path.is_ident("derive") => {
+            let mut derives = Vec::new();
+            let add_derive = |meta: ParseNestedMeta| {
+                let derive = Derive(meta.path);
+                derives.push(derive);
+
+                Ok(())
+            };
+
+            list.parse_nested_meta(add_derive).unwrap_or_else(|e| abort!(list.tokens, "failed to parse derive: {}", e));
+
+            ParsedAttribute::DeriveList(derives)
+        }
+
+        meta if contains_anywhere(meta, "bitsize_internal") => ParsedAttribute::BitsizeInternal(attribute),
+
+        _ => ParsedAttribute::Other(attribute),
+    }
+}
+
+/// a crude approximation of things we currently consider in item attributes
+enum ParsedAttribute<'attr> {
+    DeriveList(Vec<Derive>),
+    BitsizeInternal(&'attr Attribute),
+    Other(&'attr Attribute),
+}
+
+/// the path of a single derive attribute, parsed from a list which may have contained several
+#[derive(Clone)]
+struct Derive(Path);
+
+impl ToString for Derive {
+    fn to_string(&self) -> String {
+        self.0.to_token_stream().to_string()
+    }
+}
+
+impl Derive {
+    /// a new `#[derive]` attribute containing only this derive
+    fn into_attribute(self) -> Attribute {
+        let path = self.0;
+        parse_quote! { #[derive(#path)] }
+    }
+
+    /// by `bilge` convention, any derive satisfying this condition is able
+    /// to access bitfield structure information pre-compression, 
+    /// allowing for user derives
+    /// 
+    /// TODO: this method name is bikeshedable
+    fn is_bitfield_derive(&self) -> bool {
+        let last_segment = self.0.segments.last().unwrap_or_else(|| unreachable(()));
+
+        last_segment.ident.to_string().ends_with("Bits")
+    }
+}
+
+/// slightly hacky. attempts to recognize cases where an ident is deeply-nested in the meta.
+fn contains_anywhere(meta: &Meta, ident: &str) -> bool {
+    meta.to_token_stream().to_string().contains(ident)
+}

--- a/tests/ui/internal-attr-is-forbidden.rs
+++ b/tests/ui/internal-attr-is-forbidden.rs
@@ -8,4 +8,11 @@ use bilge::prelude::*;
 #[bitsize_internal]
 struct A;
 
+#[bitsize(1)]
+#[bitsize_internal]
+enum R {
+    U,
+    OK
+}
+
 fn main() {}

--- a/tests/ui/internal-attr-is-forbidden.stderr
+++ b/tests/ui/internal-attr-is-forbidden.stderr
@@ -5,3 +5,11 @@ error: remove bitsize_internal
   | ^^^^^^^^^^^^^^^^^^^
   |
   = help: attribute bitsize_internal can only be applied internally by the bitsize macros
+
+error: remove bitsize_internal
+  --> tests/ui/internal-attr-is-forbidden.rs:12:1
+   |
+12 | #[bitsize_internal]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: attribute bitsize_internal can only be applied internally by the bitsize macros

--- a/tests/ui/special-cased/zerocopy-is-not-frombits.rs
+++ b/tests/ui/special-cased/zerocopy-is-not-frombits.rs
@@ -4,4 +4,11 @@ use bilge::prelude::*;
 #[derive(zerocopy::FromBytes)]
 struct Group([bool; 32]);
 
+#[bitsize(8)]
+#[derive(zerocopy::FromBytes)]
+enum Packet {
+    A,
+    B,
+}
+
 fn main() {}

--- a/tests/ui/special-cased/zerocopy-is-not-frombits.stderr
+++ b/tests/ui/special-cased/zerocopy-is-not-frombits.stderr
@@ -1,5 +1,11 @@
-error: a bitfield struct with zerocopy::FromBytes also needs to have FromBits
+error: a bitfield with zerocopy::FromBytes also needs to have FromBits
  --> tests/ui/special-cased/zerocopy-is-not-frombits.rs:4:10
   |
 4 | #[derive(zerocopy::FromBytes)]
+  |          ^^^^^^^^^^^^^^^^^^^
+
+error: a bitfield with zerocopy::FromBytes also needs to have FromBits
+ --> tests/ui/special-cased/zerocopy-is-not-frombits.rs:8:10
+  |
+8 | #[derive(zerocopy::FromBytes)]
   |          ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
in preparation for dealing with #50, I've decided to move the attribute splitting logic to a different module. 

not that there was anything wrong with it, but I would like to make it easy to add additional interesting attributes in the future. also we didn't reject `bitsize_internal` on enums.

some TODOs in the code about stuff I wasn't sure about.