### PR TITLE
don't parse `bitsize_internal` in `#[derive(bitsize_internal)]`

### DIFF
--- a/bilge-impl/Cargo.toml
+++ b/bilge-impl/Cargo.toml
@@ -24,3 +24,6 @@ quote = "1.0"
 proc-macro2 = "1.0"
 proc-macro-error = { version = "1.0", default-features = false }
 itertools = "0.11.0"
+
+[dev-dependencies]
+syn-path = "2.0"

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -1,11 +1,13 @@
 pub mod fallback;
 pub mod discriminant_assigner;
+pub mod util;
 
 use proc_macro2::{TokenStream, Ident, Literal};
 use proc_macro_error::{abort_call_site, abort};
-use quote::{ToTokens, quote};
+use quote::quote;
 use syn::{DeriveInput, LitInt, Type, Meta, Attribute};
 use fallback::{Fallback, fallback_variant};
+use util::PathExt;
 
 /// As arbitrary_int is limited to basic rust primitives, the maximum is u128.
 /// Is there a true usecase for bitfields above this size?
@@ -179,8 +181,7 @@ pub fn to_int_match_arm(enum_name: &Ident, variant_name: &Ident, arb_int: &Token
 
 pub(crate) fn bitsize_internal_arg(attr: &Attribute) -> Option<TokenStream> {
     if let Meta::List(list) = &attr.meta {
-        let s = list.path.to_token_stream().to_string();
-        if s == "bilge :: bitsize_internal" || s == "bitsize_internal" {
+        if list.path.matches(&["bilge", "bitsize_internal"]) {
             let arg = list.tokens.to_owned();
             return Some(arg)
         }

--- a/bilge-impl/src/shared/util.rs
+++ b/bilge-impl/src/shared/util.rs
@@ -1,4 +1,6 @@
 use syn::Path;
+#[cfg(test)]
+use syn_path::path;
 
 pub trait PathExt {
     /// match path segments. `str_segments` should contain the entire
@@ -39,5 +41,51 @@ impl PathExt for Path {
         let str_segments = str_segments.iter().copied().rev();
 
         segments.zip(str_segments).all(|(a, b)| a == b)
+    }
+}
+
+#[test]
+fn path_matching() {
+    let paths = [
+        path!(::std::default::Default),
+        path!(std::default::Default),
+        path!(default::Default),
+        path!(Default),
+    ];
+
+    let str_segments = &["std", "default", "Default"];
+
+    for path in paths {
+        assert!(path.matches(str_segments));
+    }
+}
+
+#[test]
+fn partial_does_not_match() {
+    let full_path = path!(std::foo::bar::fizz::Buzz);
+
+    let str_segments = ["std", "foo", "bar", "fizz", "Buzz"];
+
+    for i in 1..str_segments.len() {
+        let partial_str_segments = &str_segments[i..];
+        assert!(!full_path.matches(partial_str_segments))
+    }
+}
+
+#[test]
+fn path_matching_without_root() {
+    let paths = [
+        path!(::core::fmt::Debug),
+        path!(core::fmt::Debug),
+        path!(::std::fmt::Debug),
+        path!(std::fmt::Debug),
+        path!(fmt::Debug),
+        path!(Debug),
+    ];
+
+    let str_segments_without_root = &["fmt", "Debug"];
+
+    for path in paths {
+        assert!(path.matches_core_or_std(str_segments_without_root));
     }
 }

--- a/bilge-impl/src/shared/util.rs
+++ b/bilge-impl/src/shared/util.rs
@@ -3,25 +3,26 @@ use syn::Path;
 pub trait PathExt {
     /// match path segments. `str_segments` should contain the entire
     /// qualified path from the crate root, for example `["bilge", "FromBits"]`.
-    /// allows partial matches - `["std", "default", "Default"]` will also match 
+    /// allows partial matches - `["std", "default", "Default"]` will also match
     /// the paths `Default` or `default::Default`.
     fn matches(&self, str_segments: &[&str]) -> bool;
-    
+
     /// match path segments, but also allow first segment to be either "core" or "std"
     fn matches_core_or_std(&self, str_segments: &[&str]) -> bool {
         let mut str_segments = str_segments.to_owned();
-        
+
         // try matching with "std" as first segment
+        // first, make "std" the first segment
         match str_segments.first().copied() {
             None => return false, // since path is non-empty, this is trivially false
-            Some("std") => (), // then no need to touch first segment
-            _ =>  str_segments.insert(0, "std"),
+            Some("std") => (),
+            _ => str_segments.insert(0, "std"),
         };
 
         if self.matches(&str_segments) {
-            return true
+            return true;
         }
-        
+
         // try matching with "core" as first segment
         str_segments[0] = "core";
         self.matches(&str_segments)
@@ -31,12 +32,12 @@ pub trait PathExt {
 impl PathExt for Path {
     fn matches(&self, str_segments: &[&str]) -> bool {
         if self.segments.len() > str_segments.len() {
-            return false
+            return false;
         }
 
         let segments = self.segments.iter().map(|seg| seg.ident.to_string()).rev();
         let str_segments = str_segments.iter().copied().rev();
-        
+
         segments.zip(str_segments).all(|(a, b)| a == b)
     }
 }

--- a/bilge-impl/src/shared/util.rs
+++ b/bilge-impl/src/shared/util.rs
@@ -1,0 +1,42 @@
+use syn::Path;
+
+pub trait PathExt {
+    /// match path segments. `str_segments` should contain the entire
+    /// qualified path from the crate root, for example `["bilge", "FromBits"]`.
+    /// allows partial matches - `["std", "default", "Default"]` will also match 
+    /// the paths `Default` or `default::Default`.
+    fn matches(&self, str_segments: &[&str]) -> bool;
+    
+    /// match path segments, but also allow first segment to be either "core" or "std"
+    fn matches_core_or_std(&self, str_segments: &[&str]) -> bool {
+        let mut str_segments = str_segments.to_owned();
+        
+        // try matching with "std" as first segment
+        match str_segments.first().copied() {
+            None => return false, // since path is non-empty, this is trivially false
+            Some("std") => (), // then no need to touch first segment
+            _ =>  str_segments.insert(0, "std"),
+        };
+
+        if self.matches(&str_segments) {
+            return true
+        }
+        
+        // try matching with "core" as first segment
+        str_segments[0] = "core";
+        self.matches(&str_segments)
+    }
+}
+
+impl PathExt for Path {
+    fn matches(&self, str_segments: &[&str]) -> bool {
+        if self.segments.len() > str_segments.len() {
+            return false
+        }
+
+        let segments = self.segments.iter().map(|seg| seg.ident.to_string()).rev();
+        let str_segments = str_segments.iter().copied().rev();
+        
+        segments.zip(str_segments).all(|(a, b)| a == b)
+    }
+}

--- a/tests/ui/internal-attr-is-forbidden.rs
+++ b/tests/ui/internal-attr-is-forbidden.rs
@@ -15,4 +15,11 @@ enum R {
     OK
 }
 
+#[bitsize(1)]
+#[derive(FromBits, bitsize_internal)]
+enum X {
+    A1,
+    A2,
+}
+
 fn main() {}

--- a/tests/ui/internal-attr-is-forbidden.stderr
+++ b/tests/ui/internal-attr-is-forbidden.stderr
@@ -13,3 +13,9 @@ error: remove bitsize_internal
    | ^^^^^^^^^^^^^^^^^^^
    |
    = help: attribute bitsize_internal can only be applied internally by the bitsize macros
+
+error: expected derive macro, found derive helper attribute `bitsize_internal`
+  --> tests/ui/internal-attr-is-forbidden.rs:19:20
+   |
+19 | #[derive(FromBits, bitsize_internal)]
+   |                    ^^^^^^^^^^^^^^^^ not a derive macro


### PR DESCRIPTION
see new UI test case for example (previously we attempted to parse it, aborting with a different error).
also adds a more robust way to compare paths.