### PR TITLE
Add DefaultBits, overwriting Default to fix its semantics

### DIFF
--- a/bilge-impl/src/bitsize/split.rs
+++ b/bilge-impl/src/bitsize/split.rs
@@ -70,13 +70,16 @@ impl SplitAttributes {
         for parsed_attr in parsed {
             match parsed_attr {
                 ParsedAttribute::DeriveList(derives) => {
-                    for derive in derives {
+                    for mut derive in derives {
                         if derive.matches(&["zerocopy", "FromBytes"]) {
                             from_bytes = Some(derive.clone());
                         } else if derive.matches(&["bilge", "FromBits"]) {
                             has_frombits = true;
                         } else if derive.matches_core_or_std(&["fmt", "Debug"]) && is_struct {
                             abort!(derive.0, "use derive(DebugBits) for structs")
+                        } else if derive.matches_core_or_std(&["fmt", "Default"]) && is_struct {
+                            // emit_warning!(derive.0, "use derive(DefaultBits) for structs")
+                            derive.0 = syn::parse2(quote::quote!(::bilge::DefaultBits)).unwrap_or_else(unreachable);
                         }
                     
                         if derive.is_custom_bitfield_derive() {

--- a/bilge-impl/src/bitsize/split.rs
+++ b/bilge-impl/src/bitsize/split.rs
@@ -77,9 +77,9 @@ impl SplitAttributes {
                             has_frombits = true;
                         } else if derive.matches_core_or_std(&["fmt", "Debug"]) && is_struct {
                             abort!(derive.0, "use derive(DebugBits) for structs")
-                        } else if derive.matches_core_or_std(&["fmt", "Default"]) && is_struct {
+                        } else if derive.matches_core_or_std(&["default", "Default"]) && is_struct {
                             // emit_warning!(derive.0, "use derive(DefaultBits) for structs")
-                            derive.0 = syn::parse2(quote::quote!(::bilge::DefaultBits)).unwrap_or_else(unreachable);
+                            derive.0 = syn::parse_quote!(::bilge::DefaultBits);
                         }
                     
                         if derive.is_custom_bitfield_derive() {

--- a/bilge-impl/src/default_bits.rs
+++ b/bilge-impl/src/default_bits.rs
@@ -1,0 +1,88 @@
+use crate::shared::{self, unreachable, BitSize, fallback::Fallback};
+use proc_macro2::{Ident, TokenStream};
+use proc_macro_error::abort_call_site;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Type};
+
+pub(crate) fn default_bits(item: TokenStream) -> TokenStream {
+    let derive_input = parse(item);
+    //TODO: does fallback need handling?
+    let (derive_data, _, name, ..) = analyze(&derive_input);
+
+    match derive_data {
+        Data::Struct(data) => generate_struct_default_impl(name, &data.fields),
+        Data::Enum(_) => abort_call_site!("use derive(Default) for enums"),
+        _ => unreachable(()),
+    }
+}
+
+fn generate_struct_default_impl(struct_name: &Ident, fields: &Fields) -> TokenStream {
+    let default_value = fields
+        .iter()
+        .map(|field| generate_default_inner(&field.ty))
+        .reduce(|acc, next| quote!(#acc | #next));
+
+    quote! {
+        impl ::core::default::Default for #struct_name {
+            fn default() -> Self {
+                let mut offset = 0;
+                let value = #default_value;
+                let value = <#struct_name as Bitsized>::ArbitraryInt::new(value);
+                Self { value }
+            }
+        }
+    }
+}
+
+fn generate_default_inner(ty: &Type) -> TokenStream {
+    use Type::*;
+    match ty {
+        // TODO?: we could optimize nested arrays here like in `struct_gen.rs`
+        Array(array) => {
+            let len_expr = &array.len;
+            let elem_ty = &*array.elem;
+            // generate the default value code for one array element
+            let value_shifted = generate_default_inner(elem_ty);
+            quote! {{
+                // constness: iter, array::from_fn, for-loop, range are not const, so we're using while loops
+                let mut acc = 0;
+                let mut i = 0;
+                while i < #len_expr {
+                    // for every element, shift its value into its place
+                    let value_shifted = #value_shifted;
+                    // and bit-or them together
+                    acc |= value_shifted;
+                    i += 1;
+                }
+                acc
+            }}
+        },
+        Path(path) => {
+            let field_size = shared::generate_type_bitsize(ty);
+            // u2::from(HaveFun::default()).value() as u32;
+            quote! {{
+                let as_int = <#path as Bitsized>::ArbitraryInt::from(#path::default()).value();
+                let as_base_int = as_int as <<Self as Bitsized>::ArbitraryInt as Number>::UnderlyingType;
+                let shifted = as_base_int << offset;
+                offset += #field_size;
+                shifted
+            }}
+        },
+        Tuple(tuple) => {
+            tuple.elems.iter()
+                .map(generate_default_inner)
+                .reduce(|acc, next| quote!(#acc | #next))
+                // `field: (),` will be handled like this:
+                .unwrap_or_else(|| quote!(0))
+        },
+        _ => unreachable(()),
+    }
+}
+
+fn parse(item: TokenStream) -> DeriveInput {
+    shared::parse_derive(item)
+}
+
+fn analyze(derive_input: &DeriveInput) -> (&Data, TokenStream, &Ident, BitSize, Option<Fallback>) {
+    shared::analyze_derive(derive_input, false)
+}

--- a/bilge-impl/src/default_bits.rs
+++ b/bilge-impl/src/default_bits.rs
@@ -38,6 +38,7 @@ fn generate_default_inner(ty: &Type) -> TokenStream {
     use Type::*;
     match ty {
         // TODO?: we could optimize nested arrays here like in `struct_gen.rs`
+        // NOTE: in std, Default is only derived for arrays with up to 32 elements, but we allow more
         Array(array) => {
             let len_expr = &array.len;
             let elem_ty = &*array.elem;
@@ -61,7 +62,7 @@ fn generate_default_inner(ty: &Type) -> TokenStream {
             let field_size = shared::generate_type_bitsize(ty);
             // u2::from(HaveFun::default()).value() as u32;
             quote! {{
-                let as_int = <#path as Bitsized>::ArbitraryInt::from(#path::default()).value();
+                let as_int = <#path as Bitsized>::ArbitraryInt::from(<#path as ::core::default::Default>::default()).value();
                 let as_base_int = as_int as <<Self as Bitsized>::ArbitraryInt as Number>::UnderlyingType;
                 let shifted = as_base_int << offset;
                 offset += #field_size;

--- a/bilge-impl/src/lib.rs
+++ b/bilge-impl/src/lib.rs
@@ -7,6 +7,7 @@ mod try_from_bits;
 mod from_bits;
 mod debug_bits;
 mod fmt_bits;
+mod default_bits;
 
 mod shared;
 
@@ -51,7 +52,7 @@ pub fn derive_from_bits(item: TokenStream) -> TokenStream {
     from_bits::from_bits(item.into()).into()
 }
 
-/// Generate an `impl Debug` for bitfield structs.
+/// Generate an `impl core::fmt::Debug` for bitfield structs.
 /// 
 /// Please use normal #[derive(Debug)] for enums.
 #[proc_macro_error]
@@ -65,4 +66,11 @@ pub fn debug_bits(item: TokenStream) -> TokenStream {
 #[proc_macro_derive(BinaryBits)]
 pub fn derive_binary_bits(item: TokenStream) -> TokenStream {
     fmt_bits::binary(item.into()).into()
+}
+
+/// Generate an `impl core::default::Default` for bitfield structs.
+#[proc_macro_error]
+#[proc_macro_derive(DefaultBits)]
+pub fn derive_default_bits(item: TokenStream) -> TokenStream {
+    default_bits::default_bits(item.into()).into()
 }

--- a/examples/nested_tuples_and_arrays.rs
+++ b/examples/nested_tuples_and_arrays.rs
@@ -3,7 +3,7 @@
 // you can use the "Expand glob import" command on
 // use bilge::prelude::*;
 // but still need to add Bitsized, Number yourself
-use bilge::prelude::{DebugBits, FromBits, TryFromBits, bitsize, u1, u18, u2, u39, Bitsized, Number};
+use bilge::prelude::{DebugBits, FromBits, TryFromBits, bitsize, u1, u18, u2, u39, Bitsized, Number, DefaultBits};
 
 
 // This file basically just informs you that yes, combinations of different nestings work.
@@ -21,15 +21,18 @@ struct Mess {
 }
 
 #[bitsize(18)]
-#[derive(TryFromBits, DebugBits, PartialEq)]
+#[derive(TryFromBits, DebugBits, PartialEq, DefaultBits)]
 struct UnfilledEnumMess {
     big_fumble: [[([[(HaveFun, u2); 2]; 1], u1); 2]; 1],
 }
 
 #[bitsize(2)]
-#[derive(TryFromBits, Debug, PartialEq, Clone, Copy)]
+#[derive(TryFromBits, Debug, PartialEq, Clone, Copy, Default)]
 enum HaveFun {
-    Yes, No, Maybe,
+    No,
+    #[default]
+    Yes,
+    Maybe,
 }
 
 // Currently array elements need to be Copy (Clone is not const and we don't have From<&T>).
@@ -97,7 +100,7 @@ fn main() {
                 u1::new(0)
             ),
             (
-                [[(HaveFun::Maybe, u2::new(3)), (HaveFun::No, u2::new(1))]],
+                [[(HaveFun::Maybe, u2::new(3)), (HaveFun::Yes, u2::new(1))]],
                 u1::new(1)
             )
         ]]
@@ -115,4 +118,7 @@ fn main() {
     mess.set_array_at(1, elem_0);
     assert_eq!(elem_1, mess.array_at(0));
     assert_eq!(elem_0, mess.array_at(1));
+
+    let default = UnfilledEnumMess::default();
+    println!("{default:?}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #[doc(no_inline)]
 pub use arbitrary_int;
-pub use bilge_impl::{bitsize, bitsize_internal, DebugBits, FromBits, TryFromBits, BinaryBits};
+pub use bilge_impl::{bitsize, bitsize_internal, DebugBits, FromBits, TryFromBits, BinaryBits, DefaultBits};
 
 /// used for `use bilge::prelude::*;`
 pub mod prelude {
@@ -11,7 +11,7 @@ pub mod prelude {
     pub use super::{
         bitsize, bitsize_internal,
         Bitsized,
-        DebugBits, FromBits, TryFromBits, BinaryBits,
+        DebugBits, FromBits, TryFromBits, BinaryBits, DefaultBits,
         // we control the version, so this should not be a problem
         arbitrary_int::*,
         Filled, assume_filled
@@ -33,7 +33,7 @@ pub unsafe trait Filled: Bitsized {}
 unsafe impl<T> Filled for T where T: Bitsized + From<<T as Bitsized>::ArbitraryInt> {}
 
 /// This is generated to statically validate that a type implements `FromBits`.
-pub fn assume_filled<T: Filled>() {}
+pub const fn assume_filled<T: Filled>() {}
 
 #[non_exhaustive]
 #[derive(Debug, PartialEq)]
@@ -43,7 +43,7 @@ pub struct BitsError;
 /// 
 /// This is needed since we don't want users to be able to create `BitsError` right now.
 /// We'll be able to turn `BitsError` into an enum later, or anything else really.
-pub fn give_me_error() -> BitsError {
+pub const fn give_me_error() -> BitsError {
     BitsError
 }
 

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -417,7 +417,7 @@ fn oob() {
 fn oob2() { Array::new([u4::new(0), u4::new(0), u4::new(0), u4::new(0)]).val_0_at(4); }
 
 #[bitsize(8)]
-#[derive(DefaultBits, PartialEq, DebugBits)]
+#[derive(Default, PartialEq, DebugBits)]
 struct NestedNonZeroDefault {
     field1: u2,
     field2: u4,

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -417,7 +417,7 @@ fn oob() {
 fn oob2() { Array::new([u4::new(0), u4::new(0), u4::new(0), u4::new(0)]).val_0_at(4); }
 
 #[bitsize(8)]
-#[derive(Default, PartialEq, DebugBits)]
+#[derive(core::default::Default, PartialEq, DebugBits)]
 struct NestedNonZeroDefault {
     field1: u2,
     field2: u4,

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -415,3 +415,37 @@ fn oob() {
 #[test]
 #[should_panic(expected = "assertion failed: index < 4")]
 fn oob2() { Array::new([u4::new(0), u4::new(0), u4::new(0), u4::new(0)]).val_0_at(4); }
+
+#[bitsize(8)]
+#[derive(DefaultBits, PartialEq, DebugBits)]
+struct NestedNonZeroDefault {
+    field1: u2,
+    field2: u4,
+    field3: Cool,
+}
+
+#[bitsize(2)]
+#[derive(Default, FromBits, PartialEq, Debug, Clone, Copy)]
+enum Cool {
+    Coool,
+    Cooool,
+    #[default]
+    CooooolDefault,
+    Cooooool,
+}
+
+#[bitsize(34)]
+#[derive(DefaultBits, PartialEq, DebugBits, FromBits)]
+struct ArrayTupleDefault {
+    field1: [[((u2, Cool, bool), (bool, bool, Cool)); 2]; 1],
+    field2: ([Cool; 2], [(u2, Cool); 3]),
+}
+
+#[test]
+fn default_bits() {
+    let default = NestedNonZeroDefault::default();
+    assert_eq!(default, NestedNonZeroDefault::new(u2::new(0), u4::new(0), Cool::CooooolDefault));
+
+    let default = ArrayTupleDefault::default();
+    assert_eq!(default, ArrayTupleDefault::from(u34::new(0b1000_1000_1000_10_10_1000_01000_1000_01000)));
+}

--- a/tests/ui/default-should-be-used.rs
+++ b/tests/ui/default-should-be-used.rs
@@ -1,0 +1,11 @@
+use bilge::prelude::*;
+
+#[bitsize(2)]
+#[derive(DefaultBits)]
+enum One {
+    Small,
+    #[default]
+    Step,
+}
+
+fn main() {}

--- a/tests/ui/default-should-be-used.rs
+++ b/tests/ui/default-should-be-used.rs
@@ -8,4 +8,19 @@ enum One {
     Step,
 }
 
+#[bitsize(2)]
+#[derive(DefaultBits)]
+struct A {
+    b: Inner,
+}
+
+#[bitsize(2)]
+#[derive(FromBits)]
+enum Inner {
+    Zero,
+    One,
+    Two,
+    Three,
+}
+
 fn main() {}

--- a/tests/ui/default-should-be-used.stderr
+++ b/tests/ui/default-should-be-used.stderr
@@ -1,0 +1,19 @@
+error: use derive(Default) for enums
+ --> tests/ui/default-should-be-used.rs:4:10
+  |
+4 | #[derive(DefaultBits)]
+  |          ^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `DefaultBits` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot find attribute `default` in this scope
+ --> tests/ui/default-should-be-used.rs:7:7
+  |
+7 |     #[default]
+  |       ^^^^^^^
+  |
+help: consider adding a derive
+  |
+3 + #[derive(Default)]
+4 + #[bitsize(2)]
+  |

--- a/tests/ui/default-should-be-used.stderr
+++ b/tests/ui/default-should-be-used.stderr
@@ -17,3 +17,11 @@ help: consider adding a derive
 3 + #[derive(Default)]
 4 + #[bitsize(2)]
   |
+
+error[E0277]: the trait bound `Inner: Default` is not satisfied
+  --> tests/ui/default-should-be-used.rs:12:10
+   |
+12 | #[derive(DefaultBits)]
+   |          ^^^^^^^^^^^ the trait `Default` is not implemented for `Inner`
+   |
+   = note: this error originates in the derive macro `DefaultBits` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Closes #50.
Taking @pickx example to explain this again, but slightly different:
```rust
#[bitsize(1)]
#[derive(Default, FromBits)]
enum HasDefault {
    A, 
    #[default]
    B
}

#[bitsize(1)]
#[derive(Default, FromBits)]
struct Foo {
    has_def: HasDefault
}
```
Here, `HasDefault::default()` would be 1.
But `Foo` is expanded like this:
```rust
#[derive(Default)]
struct Foo { value: u1 };
```
which will generate `Foo { value: 0 }` as the default, which is wrong.
Since it is completely wrong, we will now just silently change `Default` to be `DefaultBits`.

I feel like `DebugBits` should do the same. Or not `abort`.
You either want deep debugging with `DebugBits` or just want some number telling you the internal state, which `Debug` would still do.