### PR TITLE
Publish 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/lib.rs", "LICENSE-*", "README.md"]
 members = ["bilge-impl"]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.2.0"
 categories = ["data-structures", "no-std::no-alloc", "embedded", "rust-patterns"]
 description = "Use bitsized types as if they were a feature of rust."
 documentation = "https://docs.rs/bilge"
@@ -40,7 +40,7 @@ nightly = ["arbitrary-int/const_convert_and_const_trait_impl", "bilge-impl/night
 [dependencies]
 # cargo clippy workaround, we can't add `path = "../arbitrary-int"` as well
 arbitrary-int = { version = "1.2.6" }
-bilge-impl = { version = "=0.1.5", path = "bilge-impl" }
+bilge-impl = { version = "=0.2.0", path = "bilge-impl" }
 
 [dev-dependencies]
 # tests


### PR DESCRIPTION
FINALLY! A bit of a milestone, which adds all the work @pickx put into `#[fallback]` and clearing up a lot of error edge cases.
I've also gotten around to add tests for everything.

Having `Filled` as a trait now is far less hacky, more inline with what I originally wanted.
`derive(Default)` now does the right thing.
`BinaryBits` formatting should also be super useful for debugging what happens underneath the abstraction.
Again, thanks to @pickx :)

BREAKING CHANGES:
- TryFrom<uN> now returns a real error type
- FILLED was removed, now instead using a trait Filled