### PR TITLE
Add byte conversions

### DIFF
--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -48,6 +48,7 @@ struct InterruptSetEnables([bool; 32]);
 
 #[bitsize(32)]
 #[derive(FromBits, Debug, PartialEq)]
+#[repr(u32)]
 enum Subclass {
     Mouse,
     Keyboard,
@@ -83,6 +84,8 @@ fn main() {
     let num = u32::from(Subclass::from(42));
     assert_eq!(3, num);
     assert_ne!(42, num);
+
+    println!("{:?}", Subclass::from(42).to_ne_bytes());
 
     assert_eq!(Subclass2::Reserved(3), Subclass2::from(3));
     assert_eq!(Subclass2::Reserved(42), Subclass2::from(42));


### PR DESCRIPTION
Closes #33.
this is for testing big endian:
```
cargo miri test --target mips64-unknown-linux-gnuabi64
```

`&self` or `self`?
can this rotate_left-then-slice-try_into setup be easier?

also this will probably not stay in bitsize_internal, I still don't believe everyone needs this...
also useful as a trait, I mean it's basically adapted from [here](https://github.com/jimy-byerley/etherage/blob/d4e68aa559c9524d55c2b27f3e6618068dd44ad5/src/data.rs#L11) / [here](https://github.com/jimy-byerley/etherage/blob/d4e68aa559c9524d55c2b27f3e6618068dd44ad5/src/data.rs#L110).