### PR TITLE
Fix errors when a generic type comes up during bitsize macro processing

### DIFF
--- a/bilge-impl/src/bitsize_internal/struct_gen.rs
+++ b/bilge-impl/src/bitsize_internal/struct_gen.rs
@@ -165,7 +165,7 @@ pub(crate) fn generate_getter_inner(ty: &Type, is_getter: bool) -> TokenStream {
                 // generate the real value from the arbint `elem_value`
                 quote! {
                     #elem_value
-                    match #ty::try_from(elem_value) {
+                    match <#ty>::try_from(elem_value) {
                         Ok(v) => v,
                         Err(_) => panic!("unreachable"),
                     }
@@ -186,7 +186,7 @@ pub(crate) fn generate_getter_inner(ty: &Type, is_getter: bool) -> TokenStream {
                         #elem_value
                         // so, has try_from impl
                         // note this is available even if the type is `From`
-                        #ty::try_from(elem_value).is_ok()
+                        <#ty>::try_from(elem_value).is_ok()
                     } }
                 }
             }

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -468,3 +468,35 @@ fn default_bits() {
     let default = ArrayTupleDefault::default();
     assert_eq!(default, ArrayTupleDefault::from(u34::new(0b1000_1000_1000_10_10_1000_01000_1000_01000)));
 }
+
+// TODO: automatic implementation on generic struct fails
+// #[bitsize(2)]
+// #[derive(DefaultBits, PartialEq, DebugBits, FromBits)]
+#[derive(Default, Debug)]
+struct Generic<T>(u2, std::marker::PhantomData<T>);
+
+impl<T> Bitsized for Generic<T> {
+    type ArbitraryInt = u2;
+    const BITS: usize = u2::BITS;
+    const MAX: Self::ArbitraryInt = <u2 as Bitsized>::MAX;
+}
+
+impl<T> From<u2> for Generic<T> {
+    fn from(val: u2) -> Self {
+        Self(val, std::marker::PhantomData)
+    }
+}
+
+impl<T> From<Generic<T>> for u2 {
+    fn from(val: Generic<T>) -> u2 {
+        val.0
+    }
+}
+
+#[bitsize(2)]
+#[derive(DefaultBits, PartialEq, DebugBits, FromBits)]
+struct UsingGeneric(Generic<()>);
+
+#[bitsize(2)]
+#[derive(DefaultBits, PartialEq, DebugBits, TryFromBits)]
+struct UsingGenericUnfilled(Generic<()>);


### PR DESCRIPTION
Fixes #76, supersedes #64.

Adding angle brackets around a type forces it into type context, which lets us avoid having to thread things through syn's type hierarchy to try to get it to generate a turbofish. (This is kind of like a turbofish, but pointing the opposite direction.)

Trying to derive bitsize on structs that are themselves generic still fails, though I have another branch where I'm working on that: https://github.com/kitlith/bilge/tree/generic_derive

I figure I'll throw it up as a draft PR if/when this one is merged.