### PR TITLE
Derive on structs with generics

### DIFF
--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -156,7 +156,7 @@ fn generate_struct(item: &ItemStruct, declared_bitsize: u8) -> TokenStream {
 
         impl #impl_generics #ident #ty_generics #where_clause {
             // constness: when we get const blocks evaluated at compile time, add a const computed_bitsize
-            const _bitsize_check: () = assert!(
+            const _BITSIZE_CHECK: () = assert!(
                 (#computed_bitsize) == (#declared_bitsize),
                 concat!("struct size and declared bit size differ: ",
                 // stringify!(#computed_bitsize),

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -149,17 +149,21 @@ fn generate_struct(item: &ItemStruct, declared_bitsize: u8) -> TokenStream {
         }
     };
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     quote! {
         #vis struct #ident #generics #fields_def
 
-        // constness: when we get const blocks evaluated at compile time, add a const computed_bitsize
-        const _: () = assert!(
-            (#computed_bitsize) == (#declared_bitsize),
-            concat!("struct size and declared bit size differ: ",
-            // stringify!(#computed_bitsize),
-            " != ",
-            stringify!(#declared_bitsize))
-        );
+        impl #impl_generics #ident #ty_generics #where_clause {
+            // constness: when we get const blocks evaluated at compile time, add a const computed_bitsize
+            const _bitsize_check: () = assert!(
+                (#computed_bitsize) == (#declared_bitsize),
+                concat!("struct size and declared bit size differ: ",
+                // stringify!(#computed_bitsize),
+                " != ",
+                stringify!(#declared_bitsize))
+            );
+        }
     }
 }
 

--- a/bilge-impl/src/bitsize.rs
+++ b/bilge-impl/src/bitsize.rs
@@ -121,7 +121,13 @@ fn analyze_enum(bitsize: BitSize, variants: Iter<Variant>) {
 }
 
 fn generate_struct(item: &ItemStruct, declared_bitsize: u8) -> TokenStream {
-    let ItemStruct { vis, ident, fields, .. } = item;
+    let ItemStruct {
+        vis,
+        ident,
+        fields,
+        generics,
+        ..
+    } = item;
     let declared_bitsize = declared_bitsize as usize;
 
     let computed_bitsize = fields.iter().fold(quote!(0), |acc, next| {
@@ -144,7 +150,7 @@ fn generate_struct(item: &ItemStruct, declared_bitsize: u8) -> TokenStream {
     };
 
     quote! {
-        #vis struct #ident #fields_def
+        #vis struct #ident #generics #fields_def
 
         // constness: when we get const blocks evaluated at compile time, add a const computed_bitsize
         const _: () = assert!(

--- a/bilge-impl/src/bitsize_internal.rs
+++ b/bilge-impl/src/bitsize_internal.rs
@@ -92,7 +92,7 @@ fn generate_struct(struct_data: &ItemStruct, arb_int: &TokenStream) -> TokenStre
     let const_ = if cfg!(feature = "nightly") { quote!(const) } else { quote!() };
 
     quote! {
-        #vis struct #ident #generics {
+        #vis struct #ident #generics #where_clause {
             /// WARNING: modifying this value directly can break invariants
             value: #arb_int,
             _phantom: ::core::marker::PhantomData<(#(#phantom),*)>

--- a/bilge-impl/src/debug_bits.rs
+++ b/bilge-impl/src/debug_bits.rs
@@ -51,10 +51,10 @@ pub(super) fn debug_bits(item: TokenStream) -> TokenStream {
         predicates: <_>::default(),
     });
 
-    // NOTE: This is a little overkill, as it adds where clauses for concrete types as well
-    // but this is easier than trying to figure out exactly what types we need to add clauses for.
-    where_clause.predicates.extend(struct_data.fields.iter().map(|e| {
-        let ty = &e.ty;
+    // NOTE: This is not *ideal*, but it's approximately what the standard library does,
+    //  for various reasons. see https://github.com/rust-lang/rust/issues/26925
+    where_clause.predicates.extend(derive_input.generics.type_params().map(|t| {
+        let ty = &t.ident;
         let res: WherePredicate = syn::parse_quote!(#ty : ::core::fmt::Debug);
         res
     }));

--- a/bilge-impl/src/default_bits.rs
+++ b/bilge-impl/src/default_bits.rs
@@ -29,11 +29,11 @@ fn generate_struct_default_impl(struct_name: &Ident, fields: &Fields, generics: 
         predicates: <_>::default(),
     });
 
-    // NOTE: This is a little overkill, as it adds where clauses for concrete types as well
-    // but this is easier than trying to figure out exactly what types we need to add clauses for.
-    where_clause.predicates.extend(fields.iter().map(|e| {
-        let ty = &e.ty;
-        let res: WherePredicate = syn::parse_quote!(#ty : ::core::default::Default);
+    // NOTE: This is not *ideal*, but it's approximately what the standard library does,
+    //  for various reasons. see https://github.com/rust-lang/rust/issues/26925
+    where_clause.predicates.extend(generics.type_params().map(|t| {
+        let ty = &t.ident;
+        let res: WherePredicate = syn::parse_quote!(#ty : ::core::fmt::Debug);
         res
     }));
 

--- a/bilge-impl/src/default_bits.rs
+++ b/bilge-impl/src/default_bits.rs
@@ -33,7 +33,7 @@ fn generate_struct_default_impl(struct_name: &Ident, fields: &Fields, generics: 
     //  for various reasons. see https://github.com/rust-lang/rust/issues/26925
     where_clause.predicates.extend(generics.type_params().map(|t| {
         let ty = &t.ident;
-        let res: WherePredicate = syn::parse_quote!(#ty : ::core::fmt::Debug);
+        let res: WherePredicate = syn::parse_quote!(#ty : ::core::default::Default);
         res
     }));
 

--- a/bilge-impl/src/default_bits.rs
+++ b/bilge-impl/src/default_bits.rs
@@ -29,7 +29,7 @@ fn generate_struct_default_impl(struct_name: &Ident, fields: &Fields) -> TokenSt
                 let mut offset = 0;
                 let value = #default_value;
                 let value = <#struct_name as Bitsized>::ArbitraryInt::new(value);
-                Self { value }
+                Self { value, _phantom: ::core::marker::PhantomData }
             }
         }
     }

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -2,15 +2,15 @@ use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
 use proc_macro_error::{abort, abort_call_site};
 use quote::quote;
-use syn::{punctuated::Iter, Data, DeriveInput, Fields, Type, Variant};
+use syn::{punctuated::Iter, Data, DeriveInput, Fields, Generics, Type, Variant};
 
 use crate::shared::{self, discriminant_assigner::DiscriminantAssigner, enum_fills_bitsize, fallback::Fallback, unreachable, BitSize};
 
 pub(super) fn from_bits(item: TokenStream) -> TokenStream {
     let derive_input = parse(item);
-    let (derive_data, arb_int, name, internal_bitsize, fallback) = analyze(&derive_input);
+    let (derive_data, arb_int, name, generics, internal_bitsize, fallback) = analyze(&derive_input);
     let expanded = match &derive_data {
-        Data::Struct(struct_data) => generate_struct(arb_int, name, &struct_data.fields),
+        Data::Struct(struct_data) => generate_struct(arb_int, name, &struct_data.fields, generics),
         Data::Enum(enum_data) => {
             let variants = enum_data.variants.iter();
             let match_arms = analyze_enum(variants, name, internal_bitsize, fallback.as_ref(), &arb_int);
@@ -25,7 +25,7 @@ fn parse(item: TokenStream) -> DeriveInput {
     shared::parse_derive(item)
 }
 
-fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, BitSize, Option<Fallback>) {
+fn analyze(derive_input: &DeriveInput) -> (&syn::Data, TokenStream, &Ident, &Generics, BitSize, Option<Fallback>) {
     shared::analyze_derive(derive_input, false)
 }
 
@@ -141,7 +141,7 @@ fn generate_filled_check_for(ty: &Type, vec: &mut Vec<TokenStream>) {
     }
 }
 
-fn generate_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields) -> TokenStream {
+fn generate_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields, generics: &Generics) -> TokenStream {
     let const_ = if cfg!(feature = "nightly") { quote!(const) } else { quote!() };
 
     let mut assumes = Vec::new();
@@ -152,15 +152,17 @@ fn generate_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields) -
     // a single check per type is enough, so the checks can be deduped
     let assumes = assumes.into_iter().unique_by(TokenStream::to_string);
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     quote! {
-        impl #const_ ::core::convert::From<#arb_int> for #struct_type {
+        impl #impl_generics #const_ ::core::convert::From<#arb_int> for #struct_type #ty_generics #where_clause {
             fn from(value: #arb_int) -> Self {
                 #( #assumes )*
                 Self { value, _phantom: ::core::marker::PhantomData }
             }
         }
-        impl #const_ ::core::convert::From<#struct_type> for #arb_int {
-            fn from(value: #struct_type) -> Self {
+        impl #impl_generics #const_ ::core::convert::From<#struct_type #ty_generics> for #arb_int #where_clause {
+            fn from(value: #struct_type #ty_generics) -> Self {
                 value.value
             }
         }

--- a/bilge-impl/src/from_bits.rs
+++ b/bilge-impl/src/from_bits.rs
@@ -156,7 +156,7 @@ fn generate_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields) -
         impl #const_ ::core::convert::From<#arb_int> for #struct_type {
             fn from(value: #arb_int) -> Self {
                 #( #assumes )*
-                Self { value }
+                Self { value, _phantom: ::core::marker::PhantomData }
             }
         }
         impl #const_ ::core::convert::From<#struct_type> for #arb_int {

--- a/bilge-impl/src/shared.rs
+++ b/bilge-impl/src/shared.rs
@@ -6,7 +6,7 @@ use fallback::{fallback_variant, Fallback};
 use proc_macro2::{Ident, Literal, TokenStream};
 use proc_macro_error::{abort, abort_call_site};
 use quote::quote;
-use syn::{Attribute, DeriveInput, LitInt, Meta, Type};
+use syn::{Attribute, DeriveInput, Generics, LitInt, Meta, Type};
 use util::PathExt;
 
 /// As arbitrary_int is limited to basic rust primitives, the maximum is u128.
@@ -23,11 +23,11 @@ pub(crate) fn parse_derive(item: TokenStream) -> DeriveInput {
 
 // allow since we want `if try_from` blocks to stand out
 #[allow(clippy::collapsible_if)]
-pub(crate) fn analyze_derive(derive_input: &DeriveInput, try_from: bool) -> (&syn::Data, TokenStream, &Ident, BitSize, Option<Fallback>) {
+pub(crate) fn analyze_derive(derive_input: &DeriveInput, try_from: bool) -> (&syn::Data, TokenStream, &Ident, &Generics, BitSize, Option<Fallback>) {
     let DeriveInput {
         attrs,
         ident,
-        // generics,
+        generics,
         data,
         ..
     } = derive_input;
@@ -57,7 +57,7 @@ pub(crate) fn analyze_derive(derive_input: &DeriveInput, try_from: bool) -> (&sy
         abort_call_site!("fallback is not allowed with `TryFromBits`"; help = "use `#[derive(FromBits)]` or remove this `#[fallback]`")
     }
 
-    (data, arb_int, ident, bitsize, fallback)
+    (data, arb_int, ident, generics, bitsize, fallback)
 }
 
 // If we want to support bitsize(u4) besides bitsize(4), do that here.

--- a/bilge-impl/src/try_from_bits.rs
+++ b/bilge-impl/src/try_from_bits.rs
@@ -119,7 +119,7 @@ fn codegen_struct(arb_int: TokenStream, struct_type: &Ident, fields: &Fields) ->
                 let is_ok: bool = {#is_ok};
 
                 if is_ok {
-                    Ok(Self { value })
+                    Ok(Self { value, _phantom: ::core::marker::PhantomData })
                 } else {
                     Err(::bilge::give_me_error())
                 }

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -511,9 +511,12 @@ impl_from!(T; Generic<T> => u2; |val| val.0);
 struct UsingGeneric(Generic<()>);
 
 #[bitsize(2)]
-// FromBits, DefaultBits, and DebugBits don't work yet because they need the generics threaded through to the correct spot.
-#[derive(PartialEq)] // TODO: FromBits, DefaultBits, DebugBits
+#[derive(DefaultBits, PartialEq, DebugBits, FromBits)]
 struct IsGeneric<T>(Generic<T>);
+
+#[bitsize(2)]
+#[derive(DefaultBits, PartialEq, DebugBits, TryFromBits)]
+struct IsGenericUnfilled<T>(Generic<T>);
 
 #[bitsize(2)]
 #[derive(DefaultBits, PartialEq, DebugBits, TryFromBits)]

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -510,11 +510,10 @@ impl_from!(T; Generic<T> => u2; |val| val.0);
 #[derive(DefaultBits, PartialEq, DebugBits, FromBits)]
 struct UsingGeneric(Generic<()>);
 
-// TODO: bitsize doesn't work here yet because of the size check: it's trying to get the size of Generic<T> in a non-generic context
-// #[bitsize(2)]
+#[bitsize(2)]
 // FromBits, DefaultBits, and DebugBits don't work yet because they need the generics threaded through to the correct spot.
-// #[derive(PartialEq)] // TODO: FromBits, DefaultBits, DebugBits
-// struct IsGeneric<T>(Generic<T>);
+#[derive(PartialEq)] // TODO: FromBits, DefaultBits, DebugBits
+struct IsGeneric<T>(Generic<T>);
 
 #[bitsize(2)]
 #[derive(DefaultBits, PartialEq, DebugBits, TryFromBits)]

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -510,6 +510,12 @@ impl_from!(T; Generic<T> => u2; |val| val.0);
 #[derive(DefaultBits, PartialEq, DebugBits, FromBits)]
 struct UsingGeneric(Generic<()>);
 
+// TODO: bitsize doesn't work here yet because of the size check: it's trying to get the size of Generic<T> in a non-generic context
+// #[bitsize(2)]
+// FromBits, DefaultBits, and DebugBits don't work yet because they need the generics threaded through to the correct spot.
+// #[derive(PartialEq)] // TODO: FromBits, DefaultBits, DebugBits
+// struct IsGeneric<T>(Generic<T>);
+
 #[bitsize(2)]
 #[derive(DefaultBits, PartialEq, DebugBits, TryFromBits)]
 struct UsingGenericUnfilled(Generic<()>);


### PR DESCRIPTION
Still a work in progress, this mostly consists of threading generics through to the right place in each relevant macro (and i have several more macros to go), and generating the relevant PhantomData field to allow the generics to stick around.

I'm a little nervous about my potential fix for the bitsize check -- all I know so far is that it still allows it to compile, but I haven't checked if it still functions as intended yet.