### PR TITLE
Add field layout attr to manually specify bit range

### DIFF
--- a/bilge-impl/src/bitsize_internal.rs
+++ b/bilge-impl/src/bitsize_internal.rs
@@ -1,8 +1,9 @@
 use proc_macro2::{Ident, TokenStream};
-use quote::quote;
-use syn::{Attribute, Field, Item, ItemEnum, ItemStruct, Type};
+use proc_macro_error::abort;
+use quote::{format_ident, quote};
+use syn::{spanned::Spanned, Attribute, Field, Fields, Item, ItemEnum, ItemStruct, Type};
 
-use crate::shared::{self, unreachable};
+use crate::shared::{self, unreachable, FieldLayout};
 
 pub(crate) mod struct_gen;
 
@@ -15,10 +16,10 @@ struct ItemIr<'a> {
 }
 
 pub(super) fn bitsize_internal(args: TokenStream, item: TokenStream) -> TokenStream {
-    let (item, arb_int) = parse(item, args);
+    let (item, arb_int, layout) = parse(item, args);
     let ir = match item {
         Item::Struct(ref item) => {
-            let expanded = generate_struct(item, &arb_int);
+            let expanded = generate_struct(item, &arb_int, layout);
             let attrs = &item.attrs;
             let name = &item.ident;
             ItemIr { attrs, name, expanded }
@@ -34,34 +35,25 @@ pub(super) fn bitsize_internal(args: TokenStream, item: TokenStream) -> TokenStr
     generate_common(ir, &arb_int)
 }
 
-fn parse(item: TokenStream, args: TokenStream) -> (Item, TokenStream) {
+fn parse(item: TokenStream, args: TokenStream) -> (Item, TokenStream, FieldLayout) {
     let item = syn::parse2(item).unwrap_or_else(unreachable);
-    let (_declared_bitsize, arb_int) = shared::bitsize_and_arbitrary_int_from(args);
-    (item, arb_int)
+    let (_declared_bitsize, arb_int, layout) = shared::bitsize_and_arbitrary_int_from(args);
+    (item, arb_int, layout)
 }
 
-fn generate_struct(struct_data: &ItemStruct, arb_int: &TokenStream) -> TokenStream {
+fn generate_struct(struct_data: &ItemStruct, arb_int: &TokenStream, layout: FieldLayout) -> TokenStream {
     let ItemStruct { vis, ident, fields, .. } = struct_data;
 
-    let mut fieldless_next_int = 0;
-    let mut previous_field_sizes = vec![];
+    let field_offsets = match layout {
+        FieldLayout::Auto => generate_field_offsets_auto(fields),
+        FieldLayout::Manual => generate_field_offsets_manual(fields),
+    };
+
+    let field_names = generate_field_names(fields);
     let (accessors, (constructor_args, constructor_parts)): (Vec<TokenStream>, (Vec<TokenStream>, Vec<TokenStream>)) = fields
         .iter()
-        .map(|field| {
-            // offset is needed for bit-shifting
-            // struct Example { field1: u8, field2: u4, field3: u4 }
-            // previous_field_sizes = []     -> unwrap_or_else -> field_offset = 0
-            // previous_field_sizes = [8]    -> reduce         -> field_offset = 0 + 8     =  8
-            // previous_field_sizes = [8, 4] -> reduce         -> field_offset = 0 + 8 + 4 = 12
-            let field_offset = previous_field_sizes
-                .iter()
-                .cloned()
-                .reduce(|acc, next| quote!(#acc + #next))
-                .unwrap_or_else(|| quote!(0));
-            let field_size = shared::generate_type_bitsize(&field.ty);
-            previous_field_sizes.push(field_size);
-            generate_field(field, &field_offset, &mut fieldless_next_int)
-        })
+        .enumerate()
+        .map(|(idx, field)| generate_field(field, &field_offsets[idx], &field_names[idx]))
         .unzip();
 
     let const_ = if cfg!(feature = "nightly") { quote!(const) } else { quote!() };
@@ -78,7 +70,6 @@ fn generate_struct(struct_data: &ItemStruct, arb_int: &TokenStream) -> TokenStre
                 type ArbIntOf<T> = <T as Bitsized>::ArbitraryInt;
                 type BaseIntOf<T> = <ArbIntOf<T> as Number>::UnderlyingType;
 
-                let mut offset = 0;
                 let raw_value = #( #constructor_parts )|*;
                 let value = #arb_int::new(raw_value);
                 Self { value }
@@ -88,27 +79,18 @@ fn generate_struct(struct_data: &ItemStruct, arb_int: &TokenStream) -> TokenStre
     }
 }
 
-fn generate_field(field: &Field, field_offset: &TokenStream, fieldless_next_int: &mut usize) -> (TokenStream, (TokenStream, TokenStream)) {
-    let Field { ident, ty, .. } = field;
-    let name = if let Some(ident) = ident {
-        ident.clone()
-    } else {
-        let name = format!("val_{fieldless_next_int}");
-        *fieldless_next_int += 1;
-        syn::parse_str(&name).unwrap_or_else(unreachable)
-    };
+fn generate_field(field: &Field, field_offset: &TokenStream, name: &Ident) -> (TokenStream, (TokenStream, TokenStream)) {
+    let Field { ty, .. } = field;
 
     // skip reserved fields in constructors and setters
     let name_str = name.to_string();
     if name_str.contains("reserved_") || name_str.contains("padding_") {
         // needed for `DebugBits`
-        let getter = generate_getter(field, field_offset, &name);
-        let size = shared::generate_type_bitsize(ty);
+        let getter = generate_getter(field, field_offset, name);
         let accessors = quote!(#getter);
         let constructor_arg = quote!();
         let constructor_part = quote! { {
-            // we still need to shift by the element's size
-            offset += #size;
+            // reserved
             0
         } };
         return (accessors, (constructor_arg, constructor_part));
@@ -116,7 +98,7 @@ fn generate_field(field: &Field, field_offset: &TokenStream, fieldless_next_int:
 
     let getter = generate_getter(field, field_offset, &name);
     let setter = generate_setter(field, field_offset, &name);
-    let (constructor_arg, constructor_part) = generate_constructor_stuff(ty, &name);
+    let (constructor_arg, constructor_part) = generate_constructor_stuff(ty, &name, field_offset);
 
     let accessors = quote! {
         #getter
@@ -128,6 +110,7 @@ fn generate_field(field: &Field, field_offset: &TokenStream, fieldless_next_int:
 
 fn generate_getter(field: &Field, offset: &TokenStream, name: &Ident) -> TokenStream {
     let Field { attrs, vis, ty, .. } = field;
+    let attrs = remove_bit_attr(attrs);
 
     let getter_value = struct_gen::generate_getter_value(ty, offset, false);
 
@@ -165,6 +148,7 @@ fn generate_getter(field: &Field, offset: &TokenStream, name: &Ident) -> TokenSt
 
 fn generate_setter(field: &Field, offset: &TokenStream, name: &Ident) -> TokenStream {
     let Field { attrs, vis, ty, .. } = field;
+    let attrs = remove_bit_attr(attrs);
     let setter_value = struct_gen::generate_setter_value(ty, offset, false);
 
     let name: Ident = syn::parse_str(&format!("set_{name}")).unwrap_or_else(unreachable);
@@ -201,11 +185,11 @@ fn generate_setter(field: &Field, offset: &TokenStream, name: &Ident) -> TokenSt
     }
 }
 
-fn generate_constructor_stuff(ty: &Type, name: &Ident) -> (TokenStream, TokenStream) {
+fn generate_constructor_stuff(ty: &Type, name: &Ident, offset: &TokenStream) -> (TokenStream, TokenStream) {
     let constructor_arg = quote! {
         #name: #ty,
     };
-    let constructor_part = struct_gen::generate_constructor_part(ty, name);
+    let constructor_part = struct_gen::generate_constructor_part(ty, name, offset);
     (constructor_arg, constructor_part)
 }
 
@@ -232,4 +216,43 @@ fn generate_common(ir: ItemIr, arb_int: &TokenStream) -> TokenStream {
             const MAX: Self::ArbitraryInt = <Self::ArbitraryInt as Bitsized>::MAX;
         }
     }
+}
+
+fn generate_field_offsets_auto(fields: &Fields) -> Vec<TokenStream> {
+    // For auto field layout, offset of field = (offset + bit size) of previous field
+    fields.iter().take(fields.len() - 1).fold(vec![quote!(0)], |mut acc, f| {
+        let prev = acc.last().unwrap();
+        let bits = shared::generate_type_bitsize(&f.ty);
+        acc.push(quote!(#prev + #bits));
+        acc
+    })
+}
+
+fn generate_field_offsets_manual(fields: &Fields) -> Vec<TokenStream> {
+    fields
+        .iter()
+        .map(|f| {
+            let Some(attr) = shared::find_bit_range_attr(&f.attrs) else {
+                abort!(f.span(), "required #[bit]/#[bits] attribute under manual layout")
+            };
+            let range = attr.parse().unwrap_or_else(|e| abort!(e.span(), e));
+            let offset = range.start_bit;
+            quote!(#offset)
+        })
+        .collect()
+}
+
+fn generate_field_names(fields: &Fields) -> Vec<Ident> {
+    match fields {
+        Fields::Named(fields) => fields.named.iter().map(|f| f.ident.clone().unwrap()).collect(),
+        Fields::Unnamed(fields) => fields.unnamed.iter().enumerate().map(|(idx, _)| format_ident!("val_{idx}")).collect(),
+        Fields::Unit => vec![],
+    }
+}
+
+fn remove_bit_attr(attrs: &[Attribute]) -> Vec<&Attribute> {
+    attrs
+        .iter()
+        .filter(|attr| !(attr.meta.path().is_ident("bit") || attr.meta.path().is_ident("bits")))
+        .collect()
 }

--- a/bilge-impl/src/bitsize_internal/struct_gen.rs
+++ b/bilge-impl/src/bitsize_internal/struct_gen.rs
@@ -318,12 +318,13 @@ fn generate_setter_inner(ty: &Type) -> TokenStream {
 /// The constructor code just needs every field setter.
 ///
 /// [`super::generate_struct`] contains the initialization of `offset`.
-pub(crate) fn generate_constructor_part(ty: &Type, name: &Ident) -> TokenStream {
+pub(crate) fn generate_constructor_part(ty: &Type, name: &Ident, offset: &TokenStream) -> TokenStream {
     let value_shifted = generate_setter_inner(ty);
     // setters look like this: `fn set_field1(&mut self, value: u3)`
     // constructors like this: `fn new(field1: u3, field2: u4) -> Self`
     // so we need to rename `field1` -> `value` and put this in a scope
     quote! { {
+        let mut offset = #offset;
         let value = #name;
         #value_shifted
         value_shifted

--- a/bilge-impl/src/lib.rs
+++ b/bilge-impl/src/lib.rs
@@ -36,7 +36,7 @@ pub fn bitsize_internal(args: TokenStream, item: TokenStream) -> TokenStream {
 /// This should be used when your enum or enums nested in
 /// a struct don't fill their given `bitsize`.
 #[proc_macro_error]
-#[proc_macro_derive(TryFromBits, attributes(bitsize_internal, fallback))]
+#[proc_macro_derive(TryFromBits, attributes(bitsize_internal, fallback, bit, bits))]
 pub fn derive_try_from_bits(item: TokenStream) -> TokenStream {
     try_from_bits::try_from_bits(item.into()).into()
 }
@@ -56,7 +56,7 @@ pub fn derive_from_bits(item: TokenStream) -> TokenStream {
 ///
 /// Please use normal #[derive(Debug)] for enums.
 #[proc_macro_error]
-#[proc_macro_derive(DebugBits, attributes(bitsize_internal))]
+#[proc_macro_derive(DebugBits, attributes(bitsize_internal, bit, bits))]
 pub fn debug_bits(item: TokenStream) -> TokenStream {
     debug_bits::debug_bits(item.into()).into()
 }

--- a/examples/manual_layout.rs
+++ b/examples/manual_layout.rs
@@ -1,0 +1,70 @@
+#![cfg_attr(feature = "nightly", feature(const_convert, const_trait_impl, const_mut_refs))]
+use bilge::prelude::*;
+
+#[bitsize(4)]
+#[derive(DebugBits, TryFromBits, Clone, Copy)]
+struct IncompleteStruct {
+    field1: u2,
+    field2: CompleteEnum,
+}
+#[bitsize(2)]
+#[derive(Debug, FromBits, PartialEq, Eq)]
+enum CompleteEnum {
+    A = 0,
+    B = 1,
+    C = 0b0000_0010,
+    D = 3,
+}
+
+#[bitsize(32, manual)]
+#[derive(DebugBits, TryFromBits, BinaryBits)]
+struct ManualLayout1 {
+    #[bits(3..=5)]
+    a: u3,
+    #[bit(6)]
+    b: bool,
+    #[bits(10..14)]
+    c: [u2; 2],
+    #[bits(18..22)]
+    d: (u1, u3),
+    #[bits(28..32)]
+    e: IncompleteStruct,
+}
+
+// Order should not matter
+#[bitsize(32, manual)]
+#[derive(DebugBits, TryFromBits, BinaryBits)]
+struct ManualLayout2 {
+    #[bits(28..32)]
+    e: IncompleteStruct,
+    #[bits(3..=5)]
+    a: u3,
+    #[bits(10..14)]
+    c: [u2; 2],
+    #[bits(18..22)]
+    d: (u1, u3),
+    #[bit(6)]
+    b: bool,
+}
+
+fn main() {
+    let a = u3::new(0b110);
+    let b = true;
+    let c = [u2::new(0b10); 2];
+    let d = (u1::new(1), u3::new(0b011));
+    let e = IncompleteStruct::new(u2::new(0b11), CompleteEnum::C);
+    let m1_new = ManualLayout1::new(a, b, c, d, e);
+    assert_eq!(a, m1_new.a());
+    assert_eq!(b, m1_new.b());
+    assert_eq!(c, m1_new.c());
+    assert_eq!(d, m1_new.d());
+    assert_eq!(e.field1(), m1_new.e().field1());
+    assert_eq!(e.field2(), m1_new.e().field2());
+    //                   e            d          c       b  a
+    //                 /   \        /   \      /   \     | / \
+    let raw: u32 = 0b_10_11_000000_011_1_0000_10_10_000_1_110_000;
+    let m1_raw = ManualLayout1::try_from(u32::new(raw)).unwrap();
+    let m2_raw = ManualLayout2::try_from(u32::new(raw)).unwrap();
+    assert_eq!(m1_new.value, m1_raw.value);
+    assert_eq!(m1_raw.value, m2_raw.value);
+}


### PR DESCRIPTION
Hi @hecatia-elegua,

I was trying to learn low-level programming, e.g. SD driver, which interact a lot with MMIO register. Then I found several  bitfield projects like [modular-bitfield](https://github.com/hecatia-elegua/bilge#modular-bitfield), [bitbybit](https://github.com/danlehmann/bitfield#bitbybit-bit-fields-and-bit-enums) and this one, *bilge*.

After testing a while, to be honest, I feel bitbybit's design a little more fit for my usecase, especially the `#[bit(<bit index>, rw)]`/`#[bits(<start bit>..=<end bit>)]` syntax to manually specify field bit range, which is more readable when there are many gaps (reserved bits) between fields. But bitbybit misses an important feature : *derive sensible Debug impl*. Then I found bilge already resolved it by using "#[bitsize] as a scope" trick, brilliant idea!

So here I'm trying to add bitbybit style `#[bit(..)]`/`#[bits(...)]` to bilge. As a side-effect it allows overlapping field which might be helpful in some cases, e.g. multi-version register, or dangerous. (Maybe better to add a flag to switch between non-overlap and overlap mode?).

Here is a brief overview of the changes I made:
1. Add an *optional* field layout argument to `#[bitsize(...)]`, e.g. `#[bitsize(32, manual)]` means manually specify bit range for fields. Default is auto pack fields like before.
2. Add 2 helper attributes, `#[bit(<bit index>, <access mode>)` for single bit field and  `#[bits(<start bit>..=<end bit>, <access mode>)]` for multi bits field, which only allowed in manual layout. (For simplicity, *access mode* is not implemented yet.)

I'd appreciate it if you could review my changes and let me know if you have any feedback.

Thanks!