### PR TITLE
Allow more recent itertools

### DIFF
--- a/bilge-impl/Cargo.toml
+++ b/bilge-impl/Cargo.toml
@@ -24,7 +24,7 @@ syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 proc-macro-error = { version = "1.0", default-features = false }
-itertools = "0.11.0"
+itertools = ">=0.11.0, <=0.14"
 
 [dev-dependencies]
 syn-path = "2.0"


### PR DESCRIPTION
itertools has made a few backwards-incompatible releases, but the changes do not affect bilge. Allow the newer version.